### PR TITLE
fix: ensure pinned chat conversations stay sorted

### DIFF
--- a/CODE_REVIEW_AND_TEST_REPORT.md
+++ b/CODE_REVIEW_AND_TEST_REPORT.md
@@ -1,0 +1,28 @@
+# Code Review, Test Results, and Audit Suggestions
+
+## Overview
+
+- Verified the chat store's pinned conversation handling and identified a regression where externally supplied pinned IDs were not re-applied to the in-memory ordering.
+- Implemented a defensive subscription that re-runs `applyPinnedState` whenever the `pinnedConversations` array changes so pinned items stay sorted at the top regardless of state entry point.
+- Added a structural equality helper to prevent redundant resorting while ensuring the subscription can detect actual ordering changes.
+
+## Tests Executed
+
+- `pnpm --filter @agiworkforce/desktop test -- --reporter=verbose`
+- `pnpm test`
+
+## Findings and Suggestions
+
+1. **Pinned Conversation Ordering**
+   - _Issue_: Direct state hydration (e.g., from persistence or unit tests) that sets `pinnedConversations` without re-running the store logic left conversations unsorted, breaking UI expectations.
+   - _Resolution_: Introduced a store-level subscription that detects `pinnedConversations` changes and re-applies pinned ordering using the existing `applyPinnedState` helper. Added a guard (`conversationsMatchPinnedOrder`) to avoid unnecessary writes. See `apps/desktop/src/stores/chatStore.ts`.
+   - _Suggestion_: Continue to keep invariant-maintaining logic near the store layer. If new persisted fields are added, consider expanding this pattern (or extracting a small utility) to keep hydration-safe behaviour consistent.
+
+2. **Future Hardening Opportunities**
+   - Add integration coverage that simulates storage hydration to guard against future regressions related to persistence.
+   - Evaluate whether other stores rely on invariants that could benefit from similar defensive subscriptions, especially those that persist partial state via `zustand`.
+
+## Status
+
+- All unit tests across the workspace pass after the fix.
+- No additional regressions observed during the audit.


### PR DESCRIPTION
## Summary
- add a helper to compare conversation ordering and avoid redundant resorting
- subscribe to pinned conversation changes so hydration keeps pinned chats at the top
- document the review, tests executed, and audit suggestions in CODE_REVIEW_AND_TEST_REPORT.md

## Testing
- pnpm --filter @agiworkforce/desktop test -- --reporter=verbose
- pnpm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912d1e3f1c08327948330242ddb9ba0)