### PR TITLE
refactor: unify interface to Claude-like single chat experience

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -109,7 +109,7 @@ const DesktopShell = () => {
   const [agentChatVisible, setAgentChatVisible] = useState(true);
   const [missionControlVisible, setMissionControlVisible] = useState(true);
   const [onboardingComplete, setOnboardingComplete] = useState<boolean | null>(null);
-  const [currentView, setCurrentView] = useState<AppView>('chat');
+  const [currentView, setCurrentView] = useState<AppView>('enhanced-chat');
   const { theme, toggleTheme } = useTheme();
   const resolvedEditorTheme = useMemo<'light' | 'dark'>(() => {
     if (theme === 'system') {
@@ -481,83 +481,10 @@ const DesktopShell = () => {
             <GovernanceDashboard />
           </Suspense>
         );
-      case 'chat':
       default:
         return (
           <Suspense fallback={<LoadingFallback />}>
-            <div className="relative flex flex-1 overflow-hidden min-w-0">
-              {/* Agent Chat (Left) */}
-              {agentChatVisible && agentChatPosition === 'left' && (
-                <>
-                  <AgentChatInterface className="w-96 shrink-0" position="left" />
-                  <div className="w-px bg-border shrink-0" />
-                </>
-              )}
-
-              {/* Main Chat Interface */}
-              <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-                <div className="min-h-0 flex-1">
-                  <ChatInterface className="h-full" />
-                </div>
-                <InlineDiffViewer
-                  baseContent={codePreviewData.baseContent}
-                  modifiedContent={codePreviewData.modifiedContent}
-                  language={codePreviewData.language}
-                  title={codePreviewData.title}
-                  summary={codePreviewData.summary}
-                  theme={resolvedEditorTheme}
-                />
-              </div>
-
-              {/* Agent Chat (Right) */}
-              {agentChatVisible && agentChatPosition === 'right' && (
-                <>
-                  <div className="w-px bg-border shrink-0" />
-                  <AgentChatInterface className="w-96 shrink-0" position="right" />
-                </>
-              )}
-
-              {/* Mission Control */}
-              {missionControlVisible && (
-                <>
-                  <div className="w-px bg-border shrink-0" />
-                  <MissionControlPanel
-                    className="shrink-0"
-                    onClose={() => setMissionControlVisible(false)}
-                  />
-                </>
-              )}
-
-              {/* Toggle buttons */}
-              <div className="pointer-events-none absolute bottom-4 right-4 z-20 flex flex-col gap-2">
-                {!missionControlVisible && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="pointer-events-auto"
-                    onClick={() => setMissionControlVisible(true)}
-                    aria-label="Open mission control"
-                  >
-                    <PanelRightOpen className="h-4 w-4" />
-                  </Button>
-                )}
-                {!agentChatVisible && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="pointer-events-auto"
-                    onClick={() => setAgentChatVisible(true)}
-                    aria-label="Open agent chat"
-                  >
-                    {agentChatPosition === 'right' ? (
-                      <ChevronLeft className="h-4 w-4" />
-                    ) : (
-                      <ChevronRight className="h-4 w-4" />
-                    )}
-                  </Button>
-                )}
-              </div>
-            </div>
+            <EnhancedChatInterface />
           </Suspense>
         );
     }

--- a/apps/desktop/src/components/Layout/Sidebar.tsx
+++ b/apps/desktop/src/components/Layout/Sidebar.tsx
@@ -43,14 +43,7 @@ export function Sidebar({ className, onOpenSettings, currentView, onViewChange }
   const [editingTitle, setEditingTitle] = useState('');
 
   const navigationItems = [
-    { id: 'chat' as AppView, label: 'Chat', icon: MessageCircle },
-    { id: 'enhanced-chat' as AppView, label: 'AI Assistant', icon: Sparkles },
-    { id: 'agent' as AppView, label: 'Desktop Agent', icon: Zap },
-    { id: 'employees' as AppView, label: 'AI Employees', icon: Users },
-    { id: 'templates' as AppView, label: 'Templates', icon: Package },
-    { id: 'workflows' as AppView, label: 'Workflows', icon: Workflow },
-    { id: 'teams' as AppView, label: 'Teams', icon: Users },
-    { id: 'governance' as AppView, label: 'Governance', icon: Shield },
+    { id: 'enhanced-chat' as AppView, label: 'Chat', icon: MessageCircle },
   ];
 
   const filtered = useMemo(() => {
@@ -220,30 +213,30 @@ export function Sidebar({ className, onOpenSettings, currentView, onViewChange }
         )}
       </div>
 
-      {!collapsed && currentView === 'chat' && (
+      {!collapsed && currentView === 'enhanced-chat' && (
         <div className="space-y-3 px-3 pt-3">
           <Button className="w-full" onClick={handleNewTask}>
             <Plus className="mr-2 h-4 w-4" />
-            New Automation Task
+            New Chat
           </Button>
           <Input
             value={searchQuery}
             onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder="Search tasks"
+            placeholder="Search conversations"
             className="h-9 bg-background/80"
           />
         </div>
       )}
 
-      {currentView === 'chat' && (
+      {currentView === 'enhanced-chat' && (
         <ScrollArea className="flex-1 px-2 py-4">
           {filtered.length === 0 ? (
             <div className="flex h-full flex-col items-center justify-center gap-3 px-4 text-center text-sm text-muted-foreground">
               <MessageCircle className="h-5 w-5" />
-              <p>No tasks yet. Start a new automation.</p>
+              <p>No conversations yet. Start a new chat.</p>
               {!collapsed && (
                 <Button variant="link" size="sm" onClick={handleNewTask}>
-                  Start new task
+                  Start new chat
                 </Button>
               )}
             </div>
@@ -253,7 +246,7 @@ export function Sidebar({ className, onOpenSettings, currentView, onViewChange }
         </ScrollArea>
       )}
 
-      {currentView !== 'chat' && !collapsed && (
+      {currentView !== 'enhanced-chat' && !collapsed && (
         <div className="flex-1 px-4 py-6 text-center text-sm text-muted-foreground">
           <p>Navigate using the menu above</p>
         </div>

--- a/apps/desktop/src/components/Settings/SettingsPanel.tsx
+++ b/apps/desktop/src/components/Settings/SettingsPanel.tsx
@@ -10,6 +10,7 @@ import {
   Monitor,
   Shield,
   Download,
+  Users,
 } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { save } from '@tauri-apps/plugin-dialog';
@@ -27,6 +28,7 @@ import {
   createDefaultWindowPreferences,
 } from '../../stores/settingsStore';
 import { cn } from '../../lib/utils';
+import { EmployeesPage } from '../../pages/EmployeesPage';
 
 interface SettingsPanelProps {
   open: boolean;
@@ -196,7 +198,7 @@ export function SettingsPanel({ open, onOpenChange }: SettingsPanelProps) {
           </div>
         ) : (
           <Tabs defaultValue="api-keys" className="mt-6">
-            <TabsList className="grid w-full grid-cols-4">
+            <TabsList className="grid w-full grid-cols-5">
               <TabsTrigger value="api-keys" className="flex items-center gap-2">
                 <Key className="h-4 w-4" />
                 API Keys
@@ -204,6 +206,10 @@ export function SettingsPanel({ open, onOpenChange }: SettingsPanelProps) {
               <TabsTrigger value="llm-config" className="flex items-center gap-2">
                 <Settings2 className="h-4 w-4" />
                 LLM Configuration
+              </TabsTrigger>
+              <TabsTrigger value="agent-library" className="flex items-center gap-2">
+                <Users className="h-4 w-4" />
+                Agent Library
               </TabsTrigger>
               <TabsTrigger value="window" className="flex items-center gap-2">
                 <Monitor className="h-4 w-4" />
@@ -471,6 +477,12 @@ export function SettingsPanel({ open, onOpenChange }: SettingsPanelProps) {
                     </p>
                   </div>
                 </div>
+              </div>
+            </TabsContent>
+
+            <TabsContent value="agent-library" className="space-y-6 pt-6">
+              <div className="h-[600px]">
+                <EmployeesPage />
               </div>
             </TabsContent>
 


### PR DESCRIPTION
Major UI/UX refactor to create a unified chat interface similar to Claude Desktop:

Frontend Changes:
- Change default view from fragmented 'chat' to unified 'enhanced-chat'
- Remove old multi-panel chat layout (Mission Control, Agent Chat panels)
- Simplify sidebar to show only Chat and Settings
- Move AI Employees to Settings as "Agent Library" tab
- Add QuickModelSelector to chat input with Ollama as default
- Enhanced chat already shows agent work inline (thoughts, tool calls, results)

Backend Changes:
- Convert AI Employees to LLM tool definitions in chat.rs
- Main agent can now delegate to installed AI Employees as sub-agents
- Employees appear as callable tools alongside AGI registry and MCP tools

This creates a unified, Claude-like experience where all agent activity happens
inline in a single chat interface, powered by multi-LLM routing with local
Ollama default, and the ability to delegate to specialized AI Employee sub-agents.