### PR TITLE
fix: stub out unused ai_native commands and disable auto-compaction

### DIFF
--- a/apps/desktop/src-tauri/src/commands/ai_native.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_native.rs
@@ -1,261 +1,95 @@
-use crate::agent::code_generator::{CodeGenRequest, CodeGenResult, CodeGenerator};
-/// Tauri commands for AI-native software engineering features
-use crate::agent::context_manager::{Constraint, ConstraintType, ContextManager};
+// TODO: These commands are currently stubbed out because they were part of the deleted
+// agent/ module. The equivalent functionality exists in agi/ but has different APIs.
+// These commands are NOT used by the frontend, so they're safely disabled for now.
+// If needed in the future, they should be reimplemented using the agi/ module.
+
 use std::path::PathBuf;
 use std::sync::Arc;
 use tauri::State;
-use tokio::sync::{Mutex, MutexGuard};
+use tokio::sync::Mutex;
 
-/// ContextManager state
-pub struct ContextManagerState(pub Arc<Mutex<ContextManager>>);
+/// Placeholder state - not actually used
+pub struct ContextManagerState(pub Arc<Mutex<()>>);
 
-/// CodeGenerator state
-pub struct CodeGeneratorState(pub Arc<Mutex<CodeGenerator>>);
+/// Placeholder state - not actually used
+pub struct CodeGeneratorState(pub Arc<Mutex<()>>);
 
-impl ContextManagerState {
-    pub async fn lock(&self) -> MutexGuard<'_, ContextManager> {
-        self.0.lock().await
-    }
-}
-
-impl CodeGeneratorState {
-    pub async fn lock(&self) -> MutexGuard<'_, CodeGenerator> {
-        self.0.lock().await
-    }
-}
-
-/// Analyze project and build context
+/// Analyze project and build context (STUBBED - not implemented)
 #[tauri::command]
 pub async fn ai_analyze_project(
-    state: State<'_, ContextManagerState>,
-    project_root: String,
+    _state: State<'_, ContextManagerState>,
+    _project_root: String,
 ) -> Result<String, String> {
-    let mut manager = state.inner().lock().await;
-    manager.set_project_root(PathBuf::from(project_root));
-    manager
-        .analyze_project()
-        .await
-        .map_err(|e| format!("Failed to analyze project: {}", e))?;
-
-    let context = manager.get_project_context();
-    Ok(format!(
-        "Project analyzed: {} ({})",
-        context.language, context.project_type
-    ))
+    Err("ai_analyze_project is not implemented. This command was part of the deleted agent/ module.".to_string())
 }
 
-/// Add a constraint
+/// Add a constraint (STUBBED - not implemented)
 #[tauri::command]
 pub async fn ai_add_constraint(
-    state: State<'_, ContextManagerState>,
-    constraint_type: String,
-    description: String,
-    priority: u8,
-    enforced: bool,
-    metadata: serde_json::Value,
+    _state: State<'_, ContextManagerState>,
+    _constraint_type: String,
+    _description: String,
+    _priority: u8,
+    _enforced: bool,
+    _metadata: serde_json::Value,
 ) -> Result<String, String> {
-    let constraint_type = match constraint_type.as_str() {
-        "code_style" => {
-            let rules = metadata["rules"]
-                .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                        .collect()
-                })
-                .unwrap_or_default();
-            ConstraintType::CodeStyle { rules }
-        }
-        "performance" => {
-            let requirements = metadata["requirements"]
-                .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                        .collect()
-                })
-                .unwrap_or_default();
-            ConstraintType::Performance { requirements }
-        }
-        "security" => {
-            let requirements = metadata["requirements"]
-                .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                        .collect()
-                })
-                .unwrap_or_default();
-            ConstraintType::Security { requirements }
-        }
-        "architecture" => {
-            let patterns = metadata["patterns"]
-                .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                        .collect()
-                })
-                .unwrap_or_default();
-            ConstraintType::Architecture { patterns }
-        }
-        "dependencies" => {
-            let allowed = metadata["allowed"]
-                .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                        .collect()
-                })
-                .unwrap_or_default();
-            let forbidden = metadata["forbidden"]
-                .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                        .collect()
-                })
-                .unwrap_or_default();
-            ConstraintType::Dependencies { allowed, forbidden }
-        }
-        "testing" => {
-            let requirements = metadata["requirements"]
-                .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                        .collect()
-                })
-                .unwrap_or_default();
-            ConstraintType::Testing { requirements }
-        }
-        "documentation" => {
-            let requirements = metadata["requirements"]
-                .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                        .collect()
-                })
-                .unwrap_or_default();
-            ConstraintType::Documentation { requirements }
-        }
-        _ => return Err(format!("Unknown constraint type: {}", constraint_type)),
-    };
-
-    let constraint = Constraint {
-        id: uuid::Uuid::new_v4().to_string(),
-        constraint_type,
-        priority,
-        description,
-        enforced,
-    };
-
-    let mut manager = state.inner().lock().await;
-    manager.add_constraint(constraint.clone());
-
-    Ok(format!("Constraint added: {}", constraint.description))
+    Err("ai_add_constraint is not implemented. This command was part of the deleted agent/ module.".to_string())
 }
 
-/// Generate code based on description and constraints
+/// Generate code based on description and constraints (STUBBED - not implemented)
 #[tauri::command]
 pub async fn ai_generate_code(
-    state: State<'_, CodeGeneratorState>,
-    task_id: String,
-    description: String,
-    target_files: Vec<String>,
-    context: Option<String>,
-) -> Result<CodeGenResult, String> {
-    let generator = state.inner().lock().await;
-
-    // Get constraints from context manager
-    let constraints = Vec::new(); // TODO: Get from context manager
-
-    let request = CodeGenRequest {
-        task_id,
-        description,
-        target_files: target_files.into_iter().map(PathBuf::from).collect(),
-        constraints,
-        context: context.unwrap_or_default(),
-    };
-
-    generator
-        .generate_code(request)
-        .await
-        .map_err(|e| format!("Code generation failed: {}", e))
+    _state: State<'_, CodeGeneratorState>,
+    _task_id: String,
+    _description: String,
+    _target_files: Vec<String>,
+    _context: Option<String>,
+) -> Result<String, String> {
+    Err("ai_generate_code is not implemented. This command was part of the deleted agent/ module.".to_string())
 }
 
-/// Refactor existing code
+/// Refactor existing code (STUBBED - not implemented)
 #[tauri::command]
 pub async fn ai_refactor_code(
-    state: State<'_, CodeGeneratorState>,
-    files: Vec<String>,
-    description: String,
-) -> Result<CodeGenResult, String> {
-    let generator = state.inner().lock().await;
-
-    generator
-        .refactor_code(
-            files.into_iter().map(PathBuf::from).collect(),
-            description,
-            Vec::new(), // TODO: Get constraints
-        )
-        .await
-        .map_err(|e| format!("Refactoring failed: {}", e))
+    _state: State<'_, CodeGeneratorState>,
+    _files: Vec<String>,
+    _description: String,
+) -> Result<String, String> {
+    Err("ai_refactor_code is not implemented. This command was part of the deleted agent/ module.".to_string())
 }
 
-/// Generate tests for files
+/// Generate tests for files (STUBBED - not implemented)
 #[tauri::command]
 pub async fn ai_generate_tests(
-    state: State<'_, CodeGeneratorState>,
-    source_files: Vec<String>,
-    test_framework: Option<String>,
-) -> Result<Vec<crate::agent::code_generator::GeneratedFile>, String> {
-    let generator = state.inner().lock().await;
-
-    generator
-        .generate_tests(
-            source_files.into_iter().map(PathBuf::from).collect(),
-            test_framework,
-        )
-        .await
-        .map_err(|e| format!("Test generation failed: {}", e))
+    _state: State<'_, CodeGeneratorState>,
+    _source_files: Vec<String>,
+    _test_framework: Option<String>,
+) -> Result<Vec<String>, String> {
+    Err("ai_generate_tests is not implemented. This command was part of the deleted agent/ module.".to_string())
 }
 
-/// Get project context
+/// Get project context (STUBBED - not implemented)
 #[tauri::command]
 pub async fn ai_get_project_context(
-    state: State<'_, ContextManagerState>,
+    _state: State<'_, ContextManagerState>,
 ) -> Result<serde_json::Value, String> {
-    let manager = state.inner().lock().await;
-    let context = manager.get_project_context();
-
-    serde_json::to_value(context).map_err(|e| format!("Serialization failed: {}", e))
+    Err("ai_get_project_context is not implemented. This command was part of the deleted agent/ module.".to_string())
 }
 
-/// Generate context prompt for LLM
+/// Generate context prompt for LLM (STUBBED - not implemented)
 #[tauri::command]
 pub async fn ai_generate_context_prompt(
-    state: State<'_, ContextManagerState>,
-    task_description: String,
+    _state: State<'_, ContextManagerState>,
+    _task_description: String,
 ) -> Result<String, String> {
-    let manager = state.inner().lock().await;
-    Ok(manager.generate_context_prompt(&task_description))
+    Err("ai_generate_context_prompt is not implemented. This command was part of the deleted agent/ module.".to_string())
 }
 
-/// Intelligently access a file (with screenshot fallback)
+/// Intelligently access a file (with screenshot fallback) (STUBBED - not implemented)
 #[tauri::command]
 pub async fn ai_access_file(
-    file_path: String,
-    context: Option<String>,
-) -> Result<crate::agent::intelligent_file_access::FileAccessResult, String> {
-    use crate::agent::intelligent_file_access::IntelligentFileAccess;
-
-    let file_access = IntelligentFileAccess::new()
-        .map_err(|e| format!("Failed to initialize file access: {}", e))?;
-
-    file_access
-        .access_file(PathBuf::from(file_path).as_path(), context.as_deref())
-        .await
-        .map_err(|e| format!("File access failed: {}", e))
+    _file_path: String,
+    _context: Option<String>,
+) -> Result<String, String> {
+    Err("ai_access_file is not implemented. This command was part of the deleted agent/ module.".to_string())
 }

--- a/apps/desktop/src-tauri/src/commands/chat.rs
+++ b/apps/desktop/src-tauri/src/commands/chat.rs
@@ -1,5 +1,11 @@
 use super::llm::LLMState;
-use crate::agent::context_compactor::ContextCompactor;
+// TODO: Re-enable auto-compaction once ContextManager API is compatible with chat.rs
+// The deleted agent/context_compactor used std::sync::Mutex, but agi::ContextManager
+// requires tokio::sync::Mutex. Need to either:
+// 1. Change LLMState to use tokio::sync::Mutex, or
+// 2. Create an adapter/wrapper, or
+// 3. Port ContextCompactor functionality to a chat-specific helper
+// use crate::agi::ContextManager;
 use crate::db::models::{
     Conversation, ConversationCostBreakdown, CostTimeseriesPoint, Message, MessageRole,
     ProviderCostBreakdown,
@@ -25,6 +31,7 @@ pub struct AppDatabase {
     pub conn: Arc<Mutex<Connection>>,
 }
 
+/* TODO: Re-enable auto-compaction once ContextManager API is compatible
 /// Auto-compact conversation history if needed (like Cursor/Claude Code)
 async fn auto_compact_conversation(db: &AppDatabase, conversation_id: i64) -> Result<(), String> {
     let messages = {
@@ -103,6 +110,7 @@ async fn auto_compact_conversation(db: &AppDatabase, conversation_id: i64) -> Re
 
     Ok(())
 }
+*/
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateConversationRequest {
@@ -537,10 +545,10 @@ async fn chat_send_message_streaming(
         (conversation_id, user_msg_id, assistant_msg_id)
     };
 
-    // Auto-compact conversation history if needed (like Cursor/Claude Code)
-    auto_compact_conversation(&db, conversation_id)
-        .await
-        .unwrap_or_else(|e| warn!("Auto-compaction failed: {}", e));
+    // TODO: Re-enable auto-compaction once ContextManager API is compatible
+    // auto_compact_conversation(&db, conversation_id)
+    //     .await
+    //     .unwrap_or_else(|e| warn!("Auto-compaction failed: {}", e));
 
     // Get conversation history (after compaction)
     let history = {
@@ -768,10 +776,10 @@ pub async fn chat_send_message(
         (conversation_id, message)
     };
 
-    // Auto-compact conversation history if needed (like Cursor/Claude Code)
-    auto_compact_conversation(&db, conversation_id)
-        .await
-        .unwrap_or_else(|e| warn!("Auto-compaction failed: {}", e));
+    // TODO: Re-enable auto-compaction once ContextManager API is compatible
+    // auto_compact_conversation(&db, conversation_id)
+    //     .await
+    //     .unwrap_or_else(|e| warn!("Auto-compaction failed: {}", e));
 
     // 🔔 Emit agent status: Analyzing request
     let _ = app_handle.emit(


### PR DESCRIPTION
After deleting the agent/ module, fixed broken imports by:

1. Stubbed out all ai_native.rs commands (NOT used by frontend)
   - These commands required types from deleted agent/ module
   - Verified via grep: zero frontend usage
   - Added TODO comments for future reimplementation using agi/ module

2. Temporarily disabled auto-compaction in chat.rs
   - The deleted agent/context_compactor used std::sync::Mutex
   - agi::ContextManager requires tokio::sync::Mutex
   - Added TODO with 3 options to fix properly:
     - Change LLMState to use tokio::sync::Mutex, or
     - Create adapter/wrapper, or - Port ContextCompactor to chat-specific helper

These changes unblock the build while preserving functionality for proper migration later.

Changes:
- apps/desktop/src-tauri/src/commands/ai_native.rs: 95 lines (was 261)
- apps/desktop/src-tauri/src/commands/chat.rs: Commented out auto_compact_conversation()

Related: 0f5f5b5 (agent/ module deletion)

## Summary

Describe the changes and motivation.

## Related Issues

Closes #

## Changes

-

## Screenshots / Demos

## Checklist

- [ ] Tests added or updated (if applicable)
- [ ] Docs updated (README or inline)
- [ ] Lint passes (`pnpm lint`)
- [ ] Type check passes (`pnpm typecheck`)
