### PR TITLE
fix: reconcile automation module with router API after cleanup

### DIFF
--- a/apps/desktop/src-tauri/src/automation/mod.rs
+++ b/apps/desktop/src-tauri/src/automation/mod.rs
@@ -5,6 +5,7 @@ pub mod inspector;
 pub mod recorder;
 pub mod safety;
 pub mod screen;
+pub mod types;
 pub mod uia;
 pub mod vision_planner;
 

--- a/apps/desktop/src-tauri/src/automation/safety.rs
+++ b/apps/desktop/src-tauri/src/automation/safety.rs
@@ -221,7 +221,7 @@ mod tests {
         );
         assert_eq!(
             safety.get_risk_level(&ComputerAction::Scroll {
-                direction: super::super::types::ScrollDirection::Down,
+                direction: crate::automation::types::ScrollDirection::Down,
                 amount: 3
             }),
             1

--- a/apps/desktop/src-tauri/src/automation/types.rs
+++ b/apps/desktop/src-tauri/src/automation/types.rs
@@ -1,0 +1,117 @@
+// Computer use action types
+// Moved from deleted computer_use/ module during cleanup
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ComputerAction {
+    Click { x: i32, y: i32 },
+    DoubleClick { x: i32, y: i32 },
+    RightClick { x: i32, y: i32 },
+    Type { text: String },
+    Scroll { direction: ScrollDirection, amount: i32 },
+    KeyPress { key: String },
+    Wait { ms: u64 },
+    DragTo { from_x: i32, from_y: i32, to_x: i32, to_y: i32 },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScrollDirection {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionPlan {
+    pub actions: Vec<ComputerAction>,
+    pub reasoning: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProgressVerification {
+    pub task_complete: bool,
+    pub making_progress: bool,
+    pub reasoning: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComputerUseResult {
+    pub success: bool,
+    pub actions_taken: usize,
+    pub session_id: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComputerUseSession {
+    pub id: String,
+    pub user_id: String,
+    pub task_description: String,
+    pub started_at: i64,
+    pub ended_at: Option<i64>,
+    pub status: SessionStatus,
+    pub actions_taken: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    Running,
+    Completed,
+    Failed,
+    Stopped,
+}
+
+impl fmt::Display for SessionStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SessionStatus::Running => write!(f, "running"),
+            SessionStatus::Completed => write!(f, "completed"),
+            SessionStatus::Failed => write!(f, "failed"),
+            SessionStatus::Stopped => write!(f, "stopped"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComputerUseActionLog {
+    pub id: String,
+    pub session_id: String,
+    pub action_type: String,
+    pub action_data: String, // JSON serialized
+    pub screenshot_path: Option<String>,
+    pub timestamp: i64,
+    pub success: bool,
+}
+
+#[derive(Debug)]
+pub enum ComputerUseError {
+    ActionFailed(String),
+    ActionBlockedBySafety,
+    MaxIterationsReached,
+    NotMakingProgress,
+    VisionError(String),
+}
+
+impl fmt::Display for ComputerUseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ComputerUseError::ActionFailed(msg) => write!(f, "Action failed: {}", msg),
+            ComputerUseError::ActionBlockedBySafety => {
+                write!(f, "Action blocked by safety layer")
+            }
+            ComputerUseError::MaxIterationsReached => {
+                write!(f, "Maximum iterations reached without completing task")
+            }
+            ComputerUseError::NotMakingProgress => write!(f, "Task is not making progress"),
+            ComputerUseError::VisionError(msg) => write!(f, "Vision error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for ComputerUseError {}


### PR DESCRIPTION
After deleting computer_use/ module, fixed broken imports and API mismatches:

1. Created automation/types.rs (120 lines)
   - Restored ComputerAction, ActionPlan, ProgressVerification types
   - These were in deleted computer_use/types.rs
   - Required by safety.rs and vision_planner.rs

2. Fixed automation/safety.rs
   - Updated test to use crate::automation::types::ScrollDirection
   - Was referencing super::super::types which no longer existed

3. Fixed automation/vision_planner.rs (major API update)
   - Changed import from screen::capture::CapturedImage to screen::CapturedImage (capture module is private)
   - Replaced non-existent MessageContent::VisionMessage with proper router API:
     * Use ChatMessage with multimodal_content
     * ContentPart::Text + ContentPart::Image * ImageInput with PNG format and Auto detail
   - Updated call_vision_llm() to use router.invoke_candidate()
   - Added proper vision model preferences (Anthropic/Claude)

These changes unblock Rust compilation. Build now only fails on missing Linux GTK dependencies (gdk, pango, atk), which is an environment issue, not a code issue.

Changes:
- NEW: apps/desktop/src-tauri/src/automation/types.rs (120 lines)
- MOD: apps/desktop/src-tauri/src/automation/mod.rs (+1 line)
- MOD: apps/desktop/src-tauri/src/automation/safety.rs (test fix)
- MOD: apps/desktop/src-tauri/src/automation/vision_planner.rs (+49, -14 lines)

Related: 0f5f5b5 (computer_use/ deletion), 0d3a4ee (ai_native stubbing)

## Summary

Describe the changes and motivation.

## Related Issues

Closes #

## Changes

-

## Screenshots / Demos

## Checklist

- [ ] Tests added or updated (if applicable)
- [ ] Docs updated (README or inline)
- [ ] Lint passes (`pnpm lint`)
- [ ] Type check passes (`pnpm typecheck`)
