### PR TITLE
fix(desktop): cost_calculator canonicalizes model aliases — closes ultrareview bug_010

### DIFF
--- a/apps/desktop/src-tauri/src/core/llm/cost_calculator.rs
+++ b/apps/desktop/src-tauri/src/core/llm/cost_calculator.rs
@@ -180,6 +180,13 @@ impl CostCalculator {
             return 0.0;
         }
 
+        // AUDIT-FIX: bug_010 — resolve aliases (e.g. "deepseek-chat" → "deepseek-v4-flash",
+        // "kimi-k2.5" → "kimi-k2.6") so the lookup hits registered pricing instead of
+        // falling through to provider-default. Mirrors thinking.rs:229, llm_router.rs:177,
+        // provider_adapter.rs:396/2153/2886, managed_cloud_provider.rs:60.
+        let canonical = super::models_config::get_canonicalized_id(model);
+        let model = canonical.as_str();
+
         let key = (provider, model.to_string());
         let pricing = self
             .pricing
@@ -229,6 +236,11 @@ impl CostCalculator {
         if prompt_tokens == 0 && completion_tokens == 0 {
             return 0.0;
         }
+
+        // AUDIT-FIX: bug_010 — see calculate(); same alias-resolution applied here so
+        // cache-aware cost paths also honor the canonicalization map.
+        let canonical = super::models_config::get_canonicalized_id(model);
+        let model = canonical.as_str();
 
         let key = (provider, model.to_string());
         let pricing = self

--- a/apps/desktop/src-tauri/src/core/llm/tests/cost_calculator_tests.rs
+++ b/apps/desktop/src-tauri/src/core/llm/tests/cost_calculator_tests.rs
@@ -399,4 +399,32 @@ mod tests {
             cost
         );
     }
+
+    // AUDIT-FIX: bug_010 regression — alias lookup must match the canonical model's
+    // pricing, not fall through to provider-default. Before the canonicalization
+    // call was added to calculate()/calculate_with_cache(), calling with the alias
+    // returned $4.95 (Moonshot default $0.95/$4.00) while the canonical id returned
+    // $3.10 (kimi-k2.6 $0.60/$2.50). Same story for deepseek aliases.
+    #[test]
+    fn test_alias_lookup_matches_canonical_kimi() {
+        let calc = CostCalculator::new();
+        let alias = calc.calculate(Provider::Moonshot, "kimi-k2.5", 1_000_000, 1_000_000);
+        let canonical = calc.calculate(Provider::Moonshot, "kimi-k2.6", 1_000_000, 1_000_000);
+        assert!(
+            (alias - canonical).abs() < 1e-9,
+            "alias kimi-k2.5 ({alias}) should match canonical kimi-k2.6 ({canonical})"
+        );
+    }
+
+    #[test]
+    fn test_alias_lookup_matches_canonical_deepseek() {
+        let calc = CostCalculator::new();
+        let alias = calc.calculate(Provider::DeepSeek, "deepseek-chat", 1_000_000, 1_000_000);
+        let canonical =
+            calc.calculate(Provider::DeepSeek, "deepseek-v4-flash", 1_000_000, 1_000_000);
+        assert!(
+            (alias - canonical).abs() < 1e-9,
+            "alias deepseek-chat ({alias}) should match canonical deepseek-v4-flash ({canonical})"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes ultrareview **bug_010** — `CostCalculator::calculate` + `calculate_with_cache` did not canonicalize aliased model ids, causing fall-through to provider-default pricing.

Concrete impact: a caller passing `Provider::Moonshot, "kimi-k2.5"` was billed at Moonshot defaults (\$0.95 + \$4.00 = \$4.95 / 1M+1M tokens) instead of the canonical `kimi-k2.6` price (\$0.60 + \$2.50 = \$3.10). **~60 % overcharge** on `assistant_message.cost`. Same for `deepseek-chat` → `deepseek-v4-flash` (no overcharge in that specific case since defaults happen to match, but the fall-through path was wrong on principle).

## Files changed

- \`apps/desktop/src-tauri/src/core/llm/cost_calculator.rs\` — 12 lines added: 2 calls to \`super::models_config::get_canonicalized_id(model)\` at the entry of \`calculate()\` and \`calculate_with_cache()\`. Mirrors the pattern already used by \`thinking.rs:229\`, \`llm_router.rs:177\`, \`provider_adapter.rs:396/2153/2886\`, \`managed_cloud_provider.rs:60\`.
- \`apps/desktop/src-tauri/src/core/llm/tests/cost_calculator_tests.rs\` — 28 lines: 2 new regression tests asserting alias lookup matches canonical lookup for both kimi-k2.5 → k2.6 and deepseek-chat → v4-flash.

## Verification

\`\`\`
cd /Users/siddhartha/Desktop/agi-audit-fix
cargo test -p agiworkforce-desktop --lib -- core::llm::tests::cost_calculator_tests
   Finished test profile in 9m 23s
   running 4 tests
   test ...test_alias_lookup_matches_canonical_kimi ... ok
   test ...test_alias_lookup_matches_canonical_deepseek ... ok
   test ...test_moonshot_kimi_k2_6_cost ... ok
   test ...test_deepseek_v4_flash_cost ... ok
   test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 4022 filtered out
\`\`\`

## Risks

- Zero behavior change for callers already passing canonical model ids — \`get_canonicalized_id\` returns the input unchanged when no alias mapping exists for that string.
- Function shadows \`model: &str\` with a canonical \`&str\` for the rest of the body. No allocator churn beyond the single \`String\` already allocated by \`get_canonicalized_id\`.

## Follow-ups (separate PRs, identified by the audit team)

- bug_001 Paywall directory case (Linux CI blocker — was reverted by parallel codex commit b4dcfccd2)
- bug_003 CLI \`provider_dispatch.rs:70-73\` else-if order routes \`mistralai/*:free\` to Mistral instead of OpenRouter; same trap at Groq vs OpenRouter \`openai/*:free\`
- bug_009 self-healing e2e test tautology (rename or skip)
- P0.3 \`apps/cli/src/cost_ledger.rs\` 16 hardcoded model match arms + duplicate pricing table in \`tui/cost_hud.rs\`
- P2.12 desktop slash-command grouping (30 commands flat, no PlusMenu order)
- P2.10 chrome popup.css 15 hardcoded rgba (no theme switcher)
- P3.4 web ⇧Tab cycling missing on AgentModeSwitcher (only real surviving P0 UI gap)

Codex agent is concurrently editing \`apps/cli\` + \`apps/extension\` on \`fix/extension-typecheck-and-c02-sync-2026-05-20\` — defer those-tree fixes until that branch lands to avoid collision.