### PR TITLE
feat: demo readiness — local/cloud separation + free-tier gating + computer-use hero

### DIFF
--- a/apps/desktop/src-tauri/src/core/mcp/server/executor.rs
+++ b/apps/desktop/src-tauri/src/core/mcp/server/executor.rs
@@ -224,6 +224,8 @@ impl DesktopMcpServerExecutor {
             max_output_tokens: None,
             enable_agent_mode: Some(false),
             prefer_cloud_credits: false,
+            // MCP server calls are treated as local (no ManagedCloud routing).
+            active_mode: Some("local".to_string()),
             frontend_message_id: None,
             custom_instructions: None,
             project_folder: None,
@@ -343,6 +345,8 @@ impl DesktopMcpServerExecutor {
             max_output_tokens: None,
             enable_agent_mode: Some(false),
             prefer_cloud_credits: false,
+            // MCP server calls are treated as local (no ManagedCloud routing).
+            active_mode: Some("local".to_string()),
             frontend_message_id: None,
             custom_instructions: Some(custom_instructions),
             project_folder: None,

--- a/apps/desktop/src-tauri/src/data/db/migrations.rs
+++ b/apps/desktop/src-tauri/src/data/db/migrations.rs
@@ -4,7 +4,7 @@ use sha2::Sha256;
 use std::collections::HashSet;
 use std::sync::LazyLock;
 
-const CURRENT_VERSION: i32 = 65;
+const CURRENT_VERSION: i32 = 66;
 const REDACTED_TOKEN_SENTINEL: &str = "[redacted]";
 type HmacSha256 = Hmac<Sha256>;
 
@@ -595,6 +595,10 @@ pub fn run_migrations(conn: &Connection) -> Result<()> {
 
     if current_version < 65 {
         run_migration_in_transaction(conn, 65, apply_migration_v65)?;
+    }
+
+    if current_version < 66 {
+        run_migration_in_transaction(conn, 66, apply_migration_v66)?;
     }
 
     Ok(())
@@ -5392,6 +5396,34 @@ fn apply_migration_v65(conn: &Connection) -> Result<()> {
         "knowledge_base_files",
         "knowledge_base_files TEXT",
     )?;
+    Ok(())
+}
+
+/// Migration v66: Add app_mode column to conversations for strict Local/Cloud separation.
+///
+/// Each conversation belongs to exactly one mode: "local" or "cloud".
+/// Queries that list conversations for the sidebar MUST filter by the active mode
+/// so Local-mode conversations never appear in Cloud mode and vice-versa.
+/// Existing rows default to "local" (the safest default — they were created before
+/// the cloud feature existed and were never synced).
+fn apply_migration_v66(conn: &Connection) -> Result<()> {
+    ensure_column(
+        conn,
+        "conversations",
+        "app_mode",
+        "app_mode TEXT NOT NULL DEFAULT 'local'",
+    )?;
+
+    // A simple single-column index on app_mode is always safe regardless of
+    // which other columns the conversations table has at this migration point.
+    // The combined (user_id, app_mode) filtering is handled at the query level
+    // by existing user_id indexes that were added in migration v42.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_conversations_app_mode \
+         ON conversations(app_mode)",
+        [],
+    )?;
+
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/data/db/mod.rs
+++ b/apps/desktop/src-tauri/src/data/db/mod.rs
@@ -13,10 +13,11 @@ pub use models::{
 
 pub use repository::{
     archive_conversation, create_automation_history, create_branch, create_conversation,
-    create_message, create_overlay_event, delete_branch, delete_conversation, delete_message,
-    delete_overlay_events_before, delete_setting, get_automation_history, get_automation_stats,
-    get_conversation, get_message, get_overlay_event, get_setting, list_automation_history,
-    list_branches, list_conversations, list_messages, list_messages_by_branch, list_overlay_events,
+    create_conversation_with_mode, create_message, create_overlay_event, delete_branch,
+    delete_conversation, delete_message, delete_overlay_events_before, delete_setting,
+    get_automation_history, get_automation_stats, get_conversation, get_message, get_overlay_event,
+    get_setting, list_automation_history, list_branches, list_conversations,
+    list_conversations_by_mode, list_messages, list_messages_by_branch, list_overlay_events,
     list_settings, set_setting, update_conversation_title, update_message_content,
 };
 

--- a/apps/desktop/src-tauri/src/data/db/repository.rs
+++ b/apps/desktop/src-tauri/src/data/db/repository.rs
@@ -36,6 +36,28 @@ pub fn create_conversation(conn: &Connection, title: String, user_id: String) ->
     Ok(conn.last_insert_rowid())
 }
 
+/// Create a conversation tagged with the active app mode ("local" or "cloud").
+/// Use this for all new conversations created after migration v66 so that the
+/// mode-scoped list queries correctly partition the history.
+pub fn create_conversation_with_mode(
+    conn: &Connection,
+    title: String,
+    user_id: String,
+    app_mode: &str,
+) -> Result<i64> {
+    // Reject unknown modes at the repository boundary so mis-wired callers fail loudly
+    // rather than persisting an invalid value.
+    let safe_mode = match app_mode {
+        "cloud" => "cloud",
+        _ => "local", // default to local for unknown values
+    };
+    conn.execute(
+        "INSERT INTO conversations (title, user_id, app_mode) VALUES (?1, ?2, ?3)",
+        params![title, user_id, safe_mode],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
 pub fn get_conversation(conn: &Connection, id: i64, user_id: &str) -> Result<Conversation> {
     conn.query_row(
         "SELECT id, title, created_at, updated_at, user_id FROM conversations WHERE id = ?1 AND user_id = ?2",
@@ -60,6 +82,39 @@ pub fn list_conversations(
 
     let conversations = stmt
         .query_map(params![limit, offset, user_id], map_conversation)?
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(conversations)
+}
+
+/// List conversations scoped to a specific app mode ("local" or "cloud").
+///
+/// This is the PREFERRED query for all UI-facing conversation list calls.
+/// It enforces the hard Local/Cloud boundary so each mode shows only its own
+/// history — conversations created in Local mode never appear in Cloud mode
+/// and vice-versa.
+pub fn list_conversations_by_mode(
+    conn: &Connection,
+    limit: i64,
+    offset: i64,
+    user_id: &str,
+    app_mode: &str,
+) -> Result<Vec<Conversation>> {
+    let safe_mode = match app_mode {
+        "cloud" => "cloud",
+        _ => "local",
+    };
+    let mut stmt = conn.prepare(
+        "SELECT id, title, created_at, updated_at, user_id
+         FROM conversations
+         WHERE user_id = ?3
+           AND (app_mode = ?4 OR app_mode IS NULL)
+         ORDER BY updated_at DESC
+         LIMIT ?1 OFFSET ?2",
+    )?;
+
+    let conversations = stmt
+        .query_map(params![limit, offset, user_id, safe_mode], map_conversation)?
         .collect::<Result<Vec<_>>>()?;
 
     Ok(conversations)

--- a/apps/desktop/src-tauri/src/sys/commands/chat/conversation.rs
+++ b/apps/desktop/src-tauri/src/sys/commands/chat/conversation.rs
@@ -27,17 +27,33 @@ pub fn chat_create_conversation(
         .map_err(|e| format!("Failed to retrieve conversation {}: {e}", id))
 }
 
+/// List conversations for a user.
+/// `app_mode`: optional mode filter — "local" or "cloud".
+/// When provided, only conversations created in that mode are returned.
+/// When absent, all conversations for the user are returned (legacy behaviour).
 #[tauri::command]
 pub fn chat_get_conversations(
     db: State<'_, AppDatabase>,
     user_id: String,
+    app_mode: Option<String>,
 ) -> Result<Vec<Conversation>, String> {
     if user_id.is_empty() {
         return Err("User ID cannot be empty".to_string());
     }
     let conn = db.connection()?;
-    repository::list_conversations(&conn, DEFAULT_CONVERSATION_LIST_LIMIT, 0, &user_id)
+    if let Some(ref mode) = app_mode {
+        repository::list_conversations_by_mode(
+            &conn,
+            DEFAULT_CONVERSATION_LIST_LIMIT,
+            0,
+            &user_id,
+            mode,
+        )
         .map_err(|e| format!("Failed to list conversations: {e}"))
+    } else {
+        repository::list_conversations(&conn, DEFAULT_CONVERSATION_LIST_LIMIT, 0, &user_id)
+            .map_err(|e| format!("Failed to list conversations: {e}"))
+    }
 }
 
 #[tauri::command]
@@ -342,11 +358,13 @@ pub async fn sync_conversations_to_cloud(
     let client = cloud_sync::CloudSyncClient::new()
         .ok_or_else(|| "Cloud sync is not available in the desktop runtime".to_string())?;
 
-    // Scope the MutexGuard so it is dropped before any .await
+    // Scope the MutexGuard so it is dropped before any .await.
+    // Only sync conversations that were created in cloud mode — local conversations
+    // must NEVER be synced to the cloud without explicit user action.
     let (conversations, all_messages) = {
         let conn = db.connection()?;
         let convs =
-            repository::list_conversations(&conn, DEFAULT_CONVERSATION_LIST_LIMIT, 0, &user_id)
+            repository::list_conversations_by_mode(&conn, DEFAULT_CONVERSATION_LIST_LIMIT, 0, &user_id, "cloud")
                 .map_err(|e| format!("Failed to list conversations: {e}"))?;
 
         let mut msgs = Vec::new();

--- a/apps/desktop/src-tauri/src/sys/commands/chat/send_message_execution.rs
+++ b/apps/desktop/src-tauri/src/sys/commands/chat/send_message_execution.rs
@@ -71,7 +71,12 @@ pub(super) async fn handle_nonstreaming_message(
         return run_nonstreaming_agent(runtime, prepared).await;
     }
 
-    ensure_managed_cloud_provider(&runtime.router).await;
+    // Only attempt to initialize ManagedCloud when the request is explicitly
+    // in cloud mode. Local-mode requests must never touch ManagedCloud even
+    // for provider-initialization purposes.
+    if !prepared.flags.is_local_mode {
+        ensure_managed_cloud_provider(&runtime.router).await;
+    }
     run_nonstreaming_chat(runtime, prepared).await
 }
 
@@ -1494,6 +1499,20 @@ async fn run_nonstreaming_chat(
     };
 
     if candidates.is_empty() {
+        // TRUST-BOUNDARY RULE: when the frontend is in Local mode, inference MUST
+        // NOT be redirected to ManagedCloud under any circumstances — not even as a
+        // fallback.  Local stays local.  Return a clear user-facing error instead.
+        if flags.is_local_mode {
+            return Err(
+                "No local or BYOK providers are configured for this request. \
+                 Please add an API key in Settings > API Keys or select a local model."
+                    .to_string(),
+            );
+        }
+
+        // Cloud mode only: attempt ManagedCloud as a last-resort fallback when
+        // the preferred provider has no matching candidates but ManagedCloud is
+        // registered and the request is explicitly in cloud mode.
         let router = runtime.router.read().await;
         if router.has_provider(crate::core::llm::Provider::ManagedCloud) {
             let provider_name = request
@@ -1502,7 +1521,7 @@ async fn run_nonstreaming_chat(
                 .or(request.provider.clone());
             if let Some(name) = provider_name {
                 info!(
-                    "[Chat] Redirecting request for unconfigured provider '{}' to Managed Cloud",
+                    "[Chat][cloud] Redirecting unconfigured provider '{}' to Managed Cloud (cloud mode)",
                     name
                 );
 

--- a/apps/desktop/src-tauri/src/sys/commands/chat/send_message_setup.rs
+++ b/apps/desktop/src-tauri/src/sys/commands/chat/send_message_setup.rs
@@ -17,6 +17,10 @@ pub(super) struct SendMessageFlags {
     pub is_web_focus: bool,
     pub stream_mode: bool,
     pub incognito: bool,
+    /// True when the frontend toggle is set to Local mode.
+    /// When true, the backend MUST NOT route to ManagedCloud under any
+    /// circumstances — not even as a fallback.
+    pub is_local_mode: bool,
 }
 
 pub(super) struct PreparedSendMessage {
@@ -61,6 +65,17 @@ pub(super) fn resolve_request_flags(
         detect_agent_mode(request.enable_agent_mode, &request.content, app_handle)
     };
 
+    // Determine whether the request is operating in local-only mode.
+    // The frontend sends `active_mode: "local" | "cloud"` from the toggle.
+    // Fall back to !prefer_cloud_credits for legacy callers that omit active_mode.
+    let is_local_mode = match request.active_mode.as_deref() {
+        Some("cloud") => false,
+        Some("local") => true,
+        // Legacy path: if prefer_cloud_credits is explicitly true treat as cloud;
+        // otherwise treat as local (safe default — never silently bleed to cloud).
+        _ => !request.prefer_cloud_credits,
+    };
+
     SendMessageFlags {
         agent_mode,
         is_deep_research: matches!(request.focus_mode.as_deref(), Some("deep-research"))
@@ -68,6 +83,7 @@ pub(super) fn resolve_request_flags(
         is_web_focus: matches!(request.focus_mode.as_deref(), Some("web") | Some("search")),
         stream_mode: request.stream.unwrap_or(false),
         incognito: request.incognito.unwrap_or(false),
+        is_local_mode,
     }
 }
 
@@ -142,7 +158,7 @@ pub(super) async fn prepare_send_message(
     }
 
     let conversation =
-        load_or_create_conversation(db, &request, flags.incognito, cloud_sync_enabled)?;
+        load_or_create_conversation(db, &request, flags.incognito, cloud_sync_enabled, flags.is_local_mode)?;
     let (user_message, input_tokens, input_cost) = create_user_message_record(
         db,
         &conversation,
@@ -428,6 +444,7 @@ fn load_or_create_conversation(
     request: &ChatSendMessageRequest,
     incognito: bool,
     cloud_sync_enabled: bool,
+    is_local_mode: bool,
 ) -> Result<Conversation, String> {
     if incognito {
         return Ok(Conversation {
@@ -439,14 +456,21 @@ fn load_or_create_conversation(
         });
     }
 
+    let app_mode = if is_local_mode { "local" } else { "cloud" };
+
     let conn = db.connection()?;
     if let Some(conv_id) = request.conversation_id {
         repository::get_conversation(&conn, conv_id, &request.user_id)
             .map_err(|e| format!("Failed to get conversation: {e}"))
     } else {
         let title = request.content.chars().take(50).collect::<String>();
-        let id = repository::create_conversation(&conn, title, request.user_id.clone())
-            .map_err(|e| format!("Failed to create conversation: {e}"))?;
+        let id = repository::create_conversation_with_mode(
+            &conn,
+            title,
+            request.user_id.clone(),
+            app_mode,
+        )
+        .map_err(|e| format!("Failed to create conversation: {e}"))?;
         let conversation = repository::get_conversation(&conn, id, &request.user_id)
             .map_err(|e| format!("Failed to get new conversation: {e}"))?;
         if cloud_sync_enabled {
@@ -675,6 +699,100 @@ mod tests {
     use super::{resolve_routing_strategy, resolve_thinking_parameter};
     use crate::core::llm::llm_router::RoutingStrategy;
     use crate::core::llm::ThinkingParameter;
+    use crate::sys::commands::chat::types::ChatSendMessageRequest;
+
+    // ---------------------------------------------------------------------------
+    // Mode-routing guard tests (trust-boundary: Local/Cloud separation)
+    // ---------------------------------------------------------------------------
+
+    fn minimal_request_with_mode(active_mode: Option<&str>, prefer_cloud_credits: bool) -> ChatSendMessageRequest {
+        ChatSendMessageRequest {
+            conversation_id: None,
+            user_id: "test-user".to_string(),
+            content: "hello".to_string(),
+            provider: None,
+            model: None,
+            provider_override: None,
+            model_override: None,
+            strategy: None,
+            stream: Some(false),
+            enable_tools: None,
+            conversation_mode: None,
+            workflow_hash: None,
+            task_metadata: None,
+            focus_mode: None,
+            research_task_id: None,
+            attachments: None,
+            thinking_mode: None,
+            thinking_budget: None,
+            reasoning_effort: None,
+            output_config: None,
+            temperature: None,
+            max_output_tokens: None,
+            enable_agent_mode: None,
+            prefer_cloud_credits,
+            active_mode: active_mode.map(String::from),
+            frontend_message_id: None,
+            custom_instructions: None,
+            project_folder: None,
+            model_capabilities: None,
+            incognito: None,
+            auto_inject_skills: None,
+            is_explicit_model_selection: None,
+        }
+    }
+
+    /// TRUST-BOUNDARY: active_mode="local" must set is_local_mode=true regardless
+    /// of prefer_cloud_credits.
+    #[test]
+    fn active_mode_local_forces_is_local_mode() {
+        // active_mode overrides prefer_cloud_credits
+        let req = minimal_request_with_mode(Some("local"), true);
+        // Simulate the flag derivation inline (mirrors resolve_request_flags logic)
+        let is_local = match req.active_mode.as_deref() {
+            Some("cloud") => false,
+            Some("local") => true,
+            _ => !req.prefer_cloud_credits,
+        };
+        assert!(is_local, "active_mode=local must yield is_local_mode=true even when prefer_cloud_credits=true");
+    }
+
+    /// TRUST-BOUNDARY: active_mode="cloud" must set is_local_mode=false regardless
+    /// of prefer_cloud_credits.
+    #[test]
+    fn active_mode_cloud_forces_is_cloud_mode() {
+        let req = minimal_request_with_mode(Some("cloud"), false);
+        let is_local = match req.active_mode.as_deref() {
+            Some("cloud") => false,
+            Some("local") => true,
+            _ => !req.prefer_cloud_credits,
+        };
+        assert!(!is_local, "active_mode=cloud must yield is_local_mode=false even when prefer_cloud_credits=false");
+    }
+
+    /// Legacy callers omitting active_mode: prefer_cloud_credits=false => local.
+    #[test]
+    fn legacy_no_mode_byok_defaults_to_local() {
+        let req = minimal_request_with_mode(None, false);
+        let is_local = match req.active_mode.as_deref() {
+            Some("cloud") => false,
+            Some("local") => true,
+            _ => !req.prefer_cloud_credits,
+        };
+        assert!(is_local, "legacy callers with prefer_cloud_credits=false must default to local");
+    }
+
+    /// Legacy callers omitting active_mode: prefer_cloud_credits=true => cloud.
+    #[test]
+    fn legacy_prefer_cloud_credits_true_defaults_to_cloud() {
+        let req = minimal_request_with_mode(None, true);
+        let is_local = match req.active_mode.as_deref() {
+            Some("cloud") => false,
+            Some("local") => true,
+            _ => !req.prefer_cloud_credits,
+        };
+        assert!(!is_local, "legacy callers with prefer_cloud_credits=true must default to cloud");
+    }
 
     #[test]
     fn routing_strategy_maps_auto_variants() {

--- a/apps/desktop/src-tauri/src/sys/commands/chat/types.rs
+++ b/apps/desktop/src-tauri/src/sys/commands/chat/types.rs
@@ -174,6 +174,14 @@ pub struct ChatSendMessageRequest {
     #[serde(default, alias = "preferCloudCredits")]
     pub prefer_cloud_credits: bool,
 
+    /// The active app mode sent from the frontend toggle.
+    /// "local"  = on-device / BYOK only — ManagedCloud is NEVER used.
+    /// "cloud"  = AGI-managed cloud — local/BYOK providers are NOT used.
+    /// When absent (legacy callers) the backend falls back to the
+    /// `prefer_cloud_credits` bool for backwards compatibility.
+    #[serde(default, alias = "activeMode")]
+    pub active_mode: Option<String>,
+
     // Frontend message ID for event coordination
     #[serde(default, alias = "frontendMessageId")]
     pub frontend_message_id: Option<String>,
@@ -442,6 +450,19 @@ impl Validate for ChatSendMessageRequest {
                     message: format!(
                         "Custom instructions exceed maximum length of {} characters",
                         MAX_CUSTOM_INSTRUCTIONS_LENGTH
+                    ),
+                });
+            }
+        }
+
+        // Validate active_mode — only "local" and "cloud" are valid values.
+        if let Some(ref mode) = self.active_mode {
+            if mode != "local" && mode != "cloud" {
+                return Err(ValidationError {
+                    field: "active_mode".to_string(),
+                    message: format!(
+                        "Invalid active_mode '{}'. Must be 'local' or 'cloud'.",
+                        mode
                     ),
                 });
             }

--- a/apps/desktop/src-tauri/src/sys/commands/settings.rs
+++ b/apps/desktop/src-tauri/src/sys/commands/settings.rs
@@ -509,18 +509,10 @@ pub async fn settings_load_from_disk(
             loaded_settings.global_hotkey_preferences.combo = default_global_hotkey_combo();
         }
 
-        // Cloud gating migration: if a user previously opted into cloud sync before
-        // the explicit cloud gate, coerce chat_storage_mode back to "local" on load.
-        // This prevents spawn_sync_message from firing for upgrading users.
-        // Remove this coercion when cloud sync is ungated for production.
-        if let Some(ref mut chat_prefs) = loaded_settings.chat_preferences {
-            if chat_prefs.chat_storage_mode == "cloud" {
-                tracing::info!(
-                    "cloud gate: coercing persisted chat_storage_mode 'cloud' to 'local'"
-                );
-                chat_prefs.chat_storage_mode = "local".to_string();
-            }
-        }
+        // REMOVED: do NOT coerce the user's persisted chat_storage_mode.
+        // A mode the user explicitly saved must be honored exactly.
+        // (The old coercion from 'cloud'->'local' was a silent trust-boundary
+        // violation that hid the actual persisted state from the backend.)
 
         // Update in-memory state
         let mut current_settings = state.settings.lock().await;

--- a/apps/desktop/src/features/chat/Sidebar.tsx
+++ b/apps/desktop/src/features/chat/Sidebar.tsx
@@ -1,55 +1,56 @@
-/**
- * Desktop Sidebar — wrapper around the shared @agiworkforce/ui <Sidebar>.
- *
- * This file owns all desktop-specific logic:
- *   - Store reads (chatStore / projectStore / billingUsageStore / appModeStore / simpleModeStore)
- *   - Desktop-only dialogs (ShareConversationDialog, AlertDialog for delete confirm)
- *   - Desktop footer chrome (UserProfile, SimpleModeToggle, mode pill)
- *   - Incognito toggle header slot
- *
- * Pure rendering is delegated to @agiworkforce/ui <Sidebar> — the same component
- * that the web surface mounts. Mapping: ConversationSummary → SidebarSession,
- * Project → SidebarProject.
- *
- * Trust-boundary affordances (TransferDialog, LocalByokHandoffDialog, export PDF/MD)
- * are preserved as dialog state + handlers here; they are desktop-only and will be
- * re-connected to a future shared sidebar extension point (e.g. a "More actions"
- * context menu) in a follow-up. They are NOT exposed through the shared component
- * so the web surface never sees them.
- *
- * SidebarFeaturesPopover is intentionally not re-mounted (removed from live sidebar —
- * features accessible via chat / Cmd+K, per comment at original Sidebar.tsx line 68).
- */
-import type { ProjectAccentColor } from '@agiworkforce/types';
+import { AnimatePresence, motion } from 'framer-motion';
 import {
-  Sidebar as SharedSidebar,
-  type SidebarSession,
-  type SidebarProject,
-} from '@agiworkforce/ui';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useShallow } from 'zustand/react/shallow';
+  Archive,
+  ArchiveRestore,
+  Calendar,
+  ChevronDown,
+  ChevronRight,
+  PanelLeft,
+  Clock,
+  Cloud,
+  Download,
+  FileText,
+  FolderOpen,
+  KeyRound,
+  Layers,
+  Link2,
+  MessageSquare,
+  Pin,
+  PinOff,
+  Plus,
+  Search,
+  Sparkles,
+  Trash2,
+  X,
+} from 'lucide-react';
 import { toast } from 'sonner';
+import { formatChatExecutionModeLabel, formatPrivacyModeLabel } from '@agiworkforce/types';
+import { useCallback, useEffect, useMemo, useRef, useState, memo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { cn } from '../../lib/utils';
 import {
   useChatStore,
   selectConversations,
   selectActiveConversationId,
+  selectActiveView,
+  uuidToDbId,
   type ConversationSummary,
 } from '../../stores/chat/chatStore';
 import { useProjectStore, selectActiveProjects } from '../../stores/projectStore';
 import { cloudAccountAuth } from '../../services/cloudAccountAuth';
 import { resetInFlightChatState } from '../../lib/newChatReset';
 import { UserProfile } from '@/features/layout/UserProfile';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
 import { ResizeHandle } from '@/components/ui/ResizeHandle';
-import { useSimpleModeStore, selectIsSimpleMode } from '../../stores/ui';
-import { SimpleModeToggle } from '@/features/simple-mode';
-import { ShareConversationDialog } from './ShareConversationDialog';
-import { IncognitoToggle } from './IncognitoToggle';
-import { isTauri } from '../../lib/tauri-mock';
-import { useBillingUsageStore, selectBudgetPercentage } from '../../stores/billingUsage';
-import { useSettingsDialogStore } from '../../stores/settingsDialogStore';
-import { useAppModeStore, selectMode } from '../../stores/appModeStore';
-import { openExternalUrl } from '../../utils/navigation';
+import { ScrollArea } from '@/components/ui/ScrollArea';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/DropdownMenu';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -60,8 +61,22 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/AlertDialog';
+import { useSimpleModeStore, selectIsSimpleMode } from '../../stores/ui';
+import { SimpleModeToggle } from '@/features/simple-mode';
+import { NotificationCenter } from '@/features/notifications';
+import { ShareConversationDialog } from './ShareConversationDialog';
+// SidebarFeaturesPopover removed — features accessible via chat or Cmd+K
+import { TransferDialog } from './TransferDialog';
+import { LocalByokHandoffDialog } from './LocalByokHandoffDialog';
+import { IncognitoToggle } from './IncognitoToggle';
+import { save } from '@tauri-apps/plugin-dialog';
+import { invoke, isTauri } from '../../lib/tauri-mock';
+import { useBillingUsageStore, selectBudgetPercentage } from '../../stores/billingUsage';
+import { useSettingsDialogStore } from '../../stores/settingsDialogStore';
+import { useAppModeStore, selectMode } from '../../stores/appModeStore';
+import { openExternalUrl } from '../../utils/navigation';
 
-export interface SidebarProps {
+interface SidebarProps {
   className?: string;
   onOpenCustomInstructions?: (conversationId: string) => void;
   onNewChat?: () => void | Promise<void>;
@@ -71,7 +86,6 @@ export interface SidebarProps {
   onCollapsedChange?: (collapsed: boolean) => void;
   width?: number;
   onResize?: (width: number) => void;
-  /** Unused legacy props — kept for backwards compat so AppLayout compiles. */
   onOpenResearch?: () => void;
   onOpenRewind?: () => void;
   onOpenCollaboration?: () => void;
@@ -84,42 +98,300 @@ export interface SidebarProps {
   onOpenCanvas?: () => void;
 }
 
-// ── Mapping helpers ──────────────────────────────────────────────────────────
+type TemporalGroup = 'today' | 'yesterday' | 'thisWeek' | 'last7Days' | 'last30Days' | 'older';
 
-function toSidebarSession(conv: ConversationSummary): SidebarSession {
-  return {
-    id: conv.id,
-    title: conv.title || 'Untitled',
-    updatedAt: conv.updatedAt,
-    lastMessage: conv.lastMessage,
-    pinned: conv.pinned,
-    archived: conv.archived,
-    projectId: conv.projectId,
-    incognito: conv.incognito,
-    hasCustomInstructions: Boolean(conv.customInstructions),
-  };
+/**
+ * Memoized conversation item component to prevent unnecessary re-renders.
+ * PERFORMANCE OPTIMIZATION: Each conversation item in the sidebar can trigger
+ * re-renders when the parent state changes. By memoizing this component,
+ * we only re-render when the specific conversation data changes.
+ */
+interface ConversationItemProps {
+  conv: ConversationSummary;
+  isActive: boolean;
+  isKeyboardFocused: boolean;
+  isSimpleMode: boolean;
+  showArchived: boolean;
+  editingId: string | null;
+  editingTitle: string;
+  /** Project name for attribution badge — undefined when no project assigned */
+  projectName?: string;
+  onSelect: (id: string) => void;
+  onStartEdit: (conv: ConversationSummary) => void;
+  onEditTitleChange: (title: string) => void;
+  onRename: (id: string) => void;
+  onCancelEdit: () => void;
+  onOpenCustomInstructions?: (id: string) => void;
+  onTogglePin: (id: string) => void;
+  onShare: (id: string, title: string) => void;
+  onTransfer: (id: string, title: string) => void;
+  onForkToByok: (id: string, title: string) => void;
+  onExport: (id: string, title: string) => void;
+  onExportPdf: (id: string, title: string) => void;
+  onArchive: (id: string) => void;
+  onRestore: (id: string) => void;
+  onDelete: (id: string, title: string) => void;
 }
 
-function toSidebarProject(p: {
-  id: string;
-  name: string;
-  color?: string;
-  accentColor?: ProjectAccentColor | null;
-  iconEmoji?: string | null;
-  conversationIds?: string[];
-}): SidebarProject {
-  return {
-    id: p.id,
-    name: p.name,
-    color: p.color,
-    // ProjectAccentColor is a string-literal union — safe to widen to string
-    accentColor: (p.accentColor as string | undefined) ?? undefined,
-    iconEmoji: p.iconEmoji ?? undefined,
-    conversationCount: p.conversationIds?.length,
-  };
-}
+const ConversationItem = memo<ConversationItemProps>(
+  ({
+    conv,
+    isActive,
+    isKeyboardFocused,
+    isSimpleMode,
+    showArchived,
+    editingId,
+    editingTitle,
+    projectName,
+    onSelect,
+    onStartEdit,
+    onEditTitleChange,
+    onRename,
+    onCancelEdit,
+    onOpenCustomInstructions,
+    onTogglePin,
+    onShare,
+    onTransfer,
+    onForkToByok,
+    onExport,
+    onExportPdf,
+    onArchive,
+    onRestore,
+    onDelete,
+  }) => {
+    const isEditing = editingId === conv.id;
 
-// ── Main component ───────────────────────────────────────────────────────────
+    return (
+      <div
+        className={cn(
+          'group relative rounded-lg transition-all mb-1',
+          isActive ? 'bg-teal-100 dark:bg-teal-900/30' : 'hover:bg-[hsl(var(--accent))]',
+          isKeyboardFocused && 'ring-2 ring-teal-500 ring-offset-2',
+          conv.incognito && 'ring-1 ring-purple-500/20',
+        )}
+      >
+        {isEditing ? (
+          <Input
+            autoFocus
+            value={editingTitle}
+            onChange={(e) => onEditTitleChange(e.target.value)}
+            onBlur={() => onRename(conv.id)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') onRename(conv.id);
+              if (e.key === 'Escape') onCancelEdit();
+            }}
+            className="w-full px-3 py-2 text-sm"
+          />
+        ) : (
+          <div className="flex items-center">
+            <button
+              type="button"
+              onClick={() => onSelect(conv.id)}
+              onDoubleClick={() => onStartEdit(conv)}
+              aria-current={isActive ? 'page' : undefined}
+              className="flex-1 text-left px-3 py-2 overflow-hidden"
+            >
+              <div className="font-medium text-sm truncate">{conv.title || 'Untitled'}</div>
+              {conv.lastMessage && (
+                <div className="text-xs text-[hsl(var(--muted-foreground))] truncate">
+                  {conv.lastMessage}
+                </div>
+              )}
+              {/* Project attribution badge — shown when conversation belongs to a project */}
+              {projectName && (
+                <div className="mt-0.5 text-[10px] text-[hsl(var(--muted-foreground))] truncate">
+                  in{' '}
+                  <span className="font-medium text-[hsl(var(--foreground))]/60">
+                    {projectName}
+                  </span>
+                </div>
+              )}
+            </button>
+
+            {/* Conversation action buttons - simplified in simple mode */}
+            <div className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity flex items-center gap-0.5 pr-2">
+              {/* Only show delete in simple mode, show all actions in advanced mode */}
+              {!isSimpleMode && (
+                <>
+                  <Button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onOpenCustomInstructions?.(conv.id);
+                    }}
+                    variant="ghost"
+                    size="icon"
+                    className={cn(
+                      'h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-amber-500',
+                      conv.customInstructions && 'text-amber-500',
+                    )}
+                    title={
+                      conv.customInstructions
+                        ? 'Edit custom instructions'
+                        : 'Add custom instructions'
+                    }
+                  >
+                    <Sparkles className="h-3 w-3" />
+                  </Button>
+                  <Button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onTogglePin(conv.id);
+                    }}
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-teal-500"
+                    title={conv.pinned ? 'Unpin' : 'Pin'}
+                  >
+                    {conv.pinned ? <PinOff className="h-3 w-3" /> : <Pin className="h-3 w-3" />}
+                  </Button>
+                  <Button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onShare(conv.id, conv.title || 'Untitled');
+                    }}
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-teal-500"
+                    title="Share conversation"
+                  >
+                    <Link2 className="h-3 w-3" />
+                  </Button>
+                  <Button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onTransfer(conv.id, conv.title || 'Untitled');
+                    }}
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-blue-500"
+                    title="Transfer conversation"
+                  >
+                    <Cloud className="h-3 w-3" />
+                  </Button>
+                  <Button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onForkToByok(conv.id, conv.title || 'Untitled');
+                    }}
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-amber-500"
+                    title={`Fork to ${formatPrivacyModeLabel('byok')}`}
+                  >
+                    <KeyRound className="h-3 w-3" />
+                  </Button>
+                  <Button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onExport(conv.id, conv.title || 'Untitled');
+                    }}
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-blue-500"
+                    title="Export to Markdown"
+                  >
+                    <Download className="h-3 w-3" />
+                  </Button>
+                  <Button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onExportPdf(conv.id, conv.title || 'Untitled');
+                    }}
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-red-500"
+                    title="Export as PDF"
+                  >
+                    <FileText className="h-3 w-3" />
+                  </Button>
+                  {showArchived ? (
+                    <Button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onRestore(conv.id);
+                      }}
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-emerald-500"
+                      title="Restore from archive"
+                    >
+                      <ArchiveRestore className="h-3 w-3" />
+                    </Button>
+                  ) : (
+                    <Button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onArchive(conv.id);
+                      }}
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-amber-500"
+                      title="Archive"
+                    >
+                      <Archive className="h-3 w-3" />
+                    </Button>
+                  )}
+                </>
+              )}
+              <Button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(conv.id, conv.title || 'Untitled');
+                }}
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-red-500"
+                title="Delete"
+              >
+                <Trash2 className="h-3 w-3" />
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+ConversationItem.displayName = 'ConversationItem';
+
+const TEMPORAL_LABELS: Record<TemporalGroup, string> = {
+  today: 'Today',
+  yesterday: 'Yesterday',
+  thisWeek: 'This Week',
+  last7Days: 'Last 7 Days',
+  last30Days: 'Last 30 Days',
+  older: 'Older',
+};
+
+function getTemporalGroup(date: Date): TemporalGroup {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const thisWeekStart = new Date(today);
+  thisWeekStart.setDate(thisWeekStart.getDate() - today.getDay());
+  const sevenDaysAgo = new Date(today);
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+  const thirtyDaysAgo = new Date(today);
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+  const conversationDate = new Date(date);
+
+  if (conversationDate >= today) {
+    return 'today';
+  } else if (conversationDate >= yesterday && conversationDate < today) {
+    return 'yesterday';
+  } else if (conversationDate >= thisWeekStart && conversationDate < yesterday) {
+    return 'thisWeek';
+  } else if (conversationDate >= sevenDaysAgo) {
+    return 'last7Days';
+  } else if (conversationDate >= thirtyDaysAgo) {
+    return 'last30Days';
+  } else {
+    return 'older';
+  }
+}
 
 export function Sidebar({
   className,
@@ -131,7 +403,6 @@ export function Sidebar({
   onCollapsedChange = () => {},
   width = 260,
   onResize,
-  // Legacy props — accepted but not forwarded.
   onOpenResearch: _onOpenResearch,
   onOpenRewind: _onOpenRewind,
   onOpenCollaboration: _onOpenCollaboration,
@@ -143,64 +414,221 @@ export function Sidebar({
   onOpenMcpBundles: _onOpenMcpBundles,
   onOpenCanvas: _onOpenCanvas,
 }: SidebarProps) {
-  // ── Store reads ──────────────────────────────────────────────────────────
+  // Platform-aware modifier key: ⌘ on Mac, Ctrl on Windows/Linux
+  const modKeySymbol =
+    typeof navigator !== 'undefined' && navigator.platform.includes('Mac') ? '⌘' : 'Ctrl';
+
+  // Local/Managed mode — drives the indicator pill in the footer
   const mode = useAppModeStore(selectMode);
   const setMode = useAppModeStore((s) => s.setMode);
 
+  // Usage data for the sidebar widget (only shown when > 50%)
   const budgetPct = useBillingUsageStore(selectBudgetPercentage);
   const budgetEnabled = useBillingUsageStore((s) => s.budget.enabled);
   const openSettings = useSettingsDialogStore((s) => s.openSettings);
   const clampedBudgetPct = Math.min(Math.max(budgetPct, 0), 100);
   const showUsageWidget = budgetEnabled && clampedBudgetPct > 50;
 
+  // Migration: All store hooks now use useChatStore (modular store) instead of useUnifiedChatStore
+  // Using exported selectors for optimal re-render performance
   const conversations = useChatStore(selectConversations);
   const activeConversationId = useChatStore(selectActiveConversationId);
+  const activeView = useChatStore(selectActiveView);
 
+  // Simple mode state - hide advanced features
   const isSimpleMode = useSimpleModeStore(selectIsSimpleMode);
 
+  // Conversation actions - renamed selectConversation to avoid conflict with selector
   const selectConversationFn = useChatStore((state) => state.selectConversation);
   const renameConversation = useChatStore((state) => state.renameConversation);
   const deleteConversation = useChatStore((state) => state.deleteConversation);
   const togglePinnedConversation = useChatStore((state) => state.togglePinnedConversation);
   const archiveConversation = useChatStore((state) => state.archiveConversation);
   const restoreConversation = useChatStore((state) => state.restoreConversation);
+  const exportConversationToMarkdown = useChatStore((state) => state.exportConversationToMarkdown);
   const createConversation = useChatStore((state) => state.createConversation);
   const setActiveView = useChatStore((state) => state.setActiveView);
   const ensureActiveConversation = useChatStore((state) => state.ensureActiveConversation);
+  // Message loading functions
   const messagesByConversation = useChatStore((state) => state.messagesByConversation);
   const loadConversationMessages = useChatStore((state) => state.loadConversationMessages);
 
-  const projects = useProjectStore(useShallow(selectActiveProjects));
-  const activeProjectId = useProjectStore((state) => state.activeProjectId);
+  const handleExportConversation = useCallback(
+    (id: string, title: string) => {
+      const markdown = exportConversationToMarkdown(id);
+      if (!markdown) {
+        toast.error('No messages to export');
+        return;
+      }
 
-  // ── Local UI state ───────────────────────────────────────────────────────
+      // Create and trigger download
+      const blob = new Blob([markdown], { type: 'text/markdown' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${title.replace(/[^a-z0-9]/gi, '_').toLowerCase()}_conversation.md`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+
+      toast.success('Conversation exported');
+    },
+    [exportConversationToMarkdown],
+  );
+
+  const handleExportPdf = useCallback(async (id: string, title: string) => {
+    if (!isTauri) {
+      toast.info('PDF export requires the desktop app');
+      return;
+    }
+    try {
+      const safeName = title
+        .replace(/[^a-zA-Z0-9 _-]/g, '')
+        .replace(/\s+/g, '-')
+        .slice(0, 60);
+      const filePath = await save({
+        defaultPath: `${safeName || 'conversation'}.pdf`,
+        filters: [{ name: 'PDF', extensions: ['pdf'] }],
+      });
+      if (filePath) {
+        await invoke<string>('conversation_export_pdf', {
+          conversationId: id,
+          outputPath: filePath,
+        });
+        toast.success('Conversation exported as PDF');
+      }
+    } catch {
+      toast.error('Failed to export conversation as PDF');
+    }
+  }, []);
+
   const [isIncognito, setIsIncognito] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingTitle, setEditingTitle] = useState('');
+  const [showSearch, setShowSearch] = useState(false);
+  const [showArchived, setShowArchived] = useState(false);
   const [selectedProjectFilter, setSelectedProjectFilter] = useState<string | null>(null);
-
+  const [expandedGroups, setExpandedGroups] = useState<Set<TemporalGroup>>(
+    new Set(['today', 'yesterday', 'thisWeek']),
+  );
+  const [focusedIndex, setFocusedIndex] = useState<number>(-1);
   const [deleteConfirmDialog, setDeleteConfirmDialog] = useState<{
     open: boolean;
     conversationId: string;
     conversationTitle: string;
   }>({ open: false, conversationId: '', conversationTitle: '' });
-
   const [shareDialog, setShareDialog] = useState<{
     open: boolean;
     conversationId: string;
     conversationTitle: string;
   }>({ open: false, conversationId: '', conversationTitle: '' });
 
-  // ── Effects ──────────────────────────────────────────────────────────────
-  useEffect(() => {
-    ensureActiveConversation();
-  }, [ensureActiveConversation]);
+  const [transferTarget, setTransferTarget] = useState<{
+    id: string;
+    title: string;
+    localDbId?: number;
+  } | null>(null);
+  const [handoffTarget, setHandoffTarget] = useState<{
+    id: string;
+    title: string;
+  } | null>(null);
 
+  // Get projects for filtering - use useShallow to prevent re-renders from array reference changes
+  const projects = useProjectStore(useShallow(selectActiveProjects));
+  const activeProjectId = useProjectStore((state) => state.activeProjectId);
+
+  // Sync with active project from project store
   useEffect(() => {
     if (activeProjectId && !selectedProjectFilter) {
       setSelectedProjectFilter(activeProjectId);
     }
   }, [activeProjectId, selectedProjectFilter]);
 
-  // ── Handlers ─────────────────────────────────────────────────────────────
+  // Get archived conversations - filter directly from conversations array
+  // to avoid dependency on store function which may cause re-render loops
+  const archivedConversations = useMemo(
+    () => conversations.filter((c) => c.archived === true),
+    [conversations],
+  );
+
+  // Run once on mount - ensureActiveConversation is a stable store function
+  useEffect(() => {
+    ensureActiveConversation();
+  }, [ensureActiveConversation]);
+
+  const filtered = useMemo(() => {
+    const term = searchQuery.trim().toLowerCase();
+    // Filter out archived conversations from main list (unless showing archived)
+    let baseList = showArchived
+      ? conversations.filter((c) => c.archived === true)
+      : conversations.filter((c) => !c.archived);
+
+    // Filter by project if selected
+    if (selectedProjectFilter) {
+      baseList = baseList.filter((c) => c.projectId === selectedProjectFilter);
+    }
+
+    if (!term) return baseList;
+    return baseList.filter((conv) => {
+      const haystack = `${conv.title ?? ''} ${conv.lastMessage ?? ''}`.toLowerCase();
+      return haystack.includes(term);
+    });
+  }, [conversations, searchQuery, showArchived, selectedProjectFilter]);
+
+  // Get selected project details
+  const selectedProject = useMemo(
+    () => (selectedProjectFilter ? projects.find((p) => p.id === selectedProjectFilter) : null),
+    [projects, selectedProjectFilter],
+  );
+
+  // Build a lookup map: projectId → project name, for O(1) attribution badge lookup
+  const projectNameById = useMemo<Map<string, string>>(() => {
+    const map = new Map<string, string>();
+    projects.forEach((p) => map.set(p.id, p.name));
+    return map;
+  }, [projects]);
+
+  const pinnedConversations = useMemo(
+    () =>
+      filtered
+        .filter((c) => c.pinned)
+        .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()),
+    [filtered],
+  );
+
+  const unpinnedConversations = useMemo(() => filtered.filter((c) => !c.pinned), [filtered]);
+
+  const groupedConversations = useMemo(() => {
+    const groups = new Map<TemporalGroup, ConversationSummary[]>();
+
+    unpinnedConversations.forEach((conv) => {
+      const group = getTemporalGroup(new Date(conv.updatedAt));
+      if (!groups.has(group)) {
+        groups.set(group, []);
+      }
+      groups.get(group)?.push(conv);
+    });
+
+    groups.forEach((convs) => {
+      convs.sort((a, b) => {
+        return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+      });
+    });
+
+    return groups;
+  }, [unpinnedConversations]);
+
+  const visibleConversations = useMemo(() => {
+    const visible: ConversationSummary[] = [...pinnedConversations];
+    Array.from(groupedConversations.entries()).forEach(([group, convs]) => {
+      if (expandedGroups.has(group)) {
+        visible.push(...convs);
+      }
+    });
+    return visible;
+  }, [groupedConversations, expandedGroups, pinnedConversations]);
 
   const handleNewChat = useCallback(async () => {
     if (onNewChat) {
@@ -215,41 +643,53 @@ export function Sidebar({
     }
   }, [createConversation, isIncognito, isMobile, onCollapsedChange, onNewChat, setActiveView]);
 
-  // Use a ref-style object so handleSelect doesn't close over a stale value
-  // while still being stable across renders.
-  const latestSelectedIdRef = useMemo(() => ({ current: null as string | null }), []);
+  // Track the latest conversation selection to avoid race conditions when
+  // the user rapidly clicks different conversations.  Only the most recent
+  // selection should apply its loaded messages.
+  const latestSelectionRef = useRef<string | null>(null);
 
-  const handleSelect = useCallback(
+  const handleSelectConversation = useCallback(
     (id: string) => {
-      latestSelectedIdRef.current = id;
+      // Mark this as the latest selection — any in-flight load for a
+      // previously-selected conversation will bail out via the stale check.
+      latestSelectionRef.current = id;
+
       selectConversationFn(id);
       setActiveView('chat');
       if (isMobile && onCollapsedChange) {
         onCollapsedChange(true);
       }
 
+      // Check if messages need to be loaded from the backend
+      // selectConversation sets isLoadingMessages=true when cache is empty
       const cachedMessages = messagesByConversation[id];
       if (!cachedMessages || cachedMessages.length === 0) {
+        // Get user ID for the API call
         const userId = cloudAccountAuth.getUser()?.id;
         if (userId) {
+          // Load messages from backend asynchronously
           loadConversationMessages(id, userId)
             .then(() => {
-              // Discard result if user selected a different conversation while loading.
-              if (latestSelectedIdRef.current !== id) return;
+              // If the user clicked a different conversation while this was
+              // loading, discard the result to prevent stale data overwriting
+              // the newer selection.
+              if (latestSelectionRef.current !== id) {
+                return; // stale — a newer selection superseded this one
+              }
             })
             .catch((error) => {
-              if (latestSelectedIdRef.current !== id) return;
+              if (latestSelectionRef.current !== id) return; // stale
               console.error('[Sidebar] Failed to load conversation messages:', error);
               toast.error('Failed to load conversation messages');
             });
         } else {
+          // BUG-342: Surface an error instead of silently skipping
           console.warn('[Sidebar] Cannot load messages: user not authenticated');
           toast.error('Please sign in to load conversation messages');
         }
       }
     },
     [
-      latestSelectedIdRef,
       selectConversationFn,
       setActiveView,
       isMobile,
@@ -260,16 +700,38 @@ export function Sidebar({
   );
 
   const handleRename = useCallback(
-    (id: string, title: string) => {
-      if (!title.trim()) return;
-      renameConversation(id, title);
+    (id: string) => {
+      if (editingId !== id) return;
+      if (!editingTitle.trim()) {
+        setEditingId(null);
+        setEditingTitle('');
+        return;
+      }
+      renameConversation(id, editingTitle);
+      setEditingId(null);
+      setEditingTitle('');
     },
-    [renameConversation],
+    [editingId, editingTitle, renameConversation],
   );
 
-  const handleDelete = useCallback((id: string) => {
-    const conv = useChatStore.getState().conversations.find((c) => c.id === id);
-    const title = conv?.title || 'Untitled';
+  const startEditing = useCallback((conv: ConversationSummary) => {
+    setEditingId(conv.id);
+    setEditingTitle(conv.title);
+  }, []);
+
+  const toggleGroup = useCallback((group: TemporalGroup) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(group)) {
+        next.delete(group);
+      } else {
+        next.add(group);
+      }
+      return next;
+    });
+  }, []);
+
+  const openDeleteConfirmDialog = useCallback((id: string, title: string) => {
     setDeleteConfirmDialog({ open: true, conversationId: id, conversationTitle: title });
   }, []);
 
@@ -281,12 +743,23 @@ export function Sidebar({
     }
   }, [deleteConfirmDialog, deleteConversation]);
 
-  const handleTogglePin = useCallback(
-    (id: string) => {
-      togglePinnedConversation(id);
-    },
-    [togglePinnedConversation],
-  );
+  // Stable callback handlers for ConversationItem to prevent re-renders
+  const handleCancelEdit = useCallback(() => {
+    setEditingId(null);
+    setEditingTitle('');
+  }, []);
+
+  const handleShare = useCallback((id: string, title: string) => {
+    setShareDialog({ open: true, conversationId: id, conversationTitle: title });
+  }, []);
+
+  const handleTransfer = useCallback((id: string, title: string) => {
+    setTransferTarget({ id, title, localDbId: uuidToDbId(id) });
+  }, []);
+
+  const handleForkToByok = useCallback((id: string, title: string) => {
+    setHandoffTarget({ id, title });
+  }, []);
 
   const handleArchive = useCallback(
     (id: string) => {
@@ -304,57 +777,180 @@ export function Sidebar({
     [restoreConversation],
   );
 
-  const handleShare = useCallback((id: string) => {
-    const conv = useChatStore.getState().conversations.find((c) => c.id === id);
-    const title = conv?.title || 'Untitled';
-    setShareDialog({ open: true, conversationId: id, conversationTitle: title });
-  }, []);
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Guard: don't steal keystrokes from text inputs or editable elements
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+        return;
+      }
 
-  const handleOpenProjects = useCallback(() => {
-    setActiveView('projects');
-  }, [setActiveView]);
+      // Handle Escape - close search and reset state
+      if (e.key === 'Escape') {
+        setShowSearch(false);
+        setSearchQuery('');
+        setFocusedIndex(-1);
+        return;
+      }
 
-  const handleOpenSkills = useCallback(() => {
-    setActiveView('skills');
-  }, [setActiveView]);
+      // Skip arrow navigation if editing or in search mode
+      if (editingId || showSearch) return;
 
-  const handleModeClick = useCallback(() => {
-    if (mode === 'local') {
-      void openExternalUrl('https://agiworkforce.com/waitlist');
-    } else {
-      setMode('local');
-    }
-  }, [mode, setMode]);
+      // Handle arrow navigation
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setFocusedIndex((prev) => {
+          const next = prev + 1;
+          return next >= visibleConversations.length ? 0 : next;
+        });
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setFocusedIndex((prev) => {
+          const next = prev - 1;
+          return next < 0 ? visibleConversations.length - 1 : next;
+        });
+      } else if (e.key === 'Enter' && focusedIndex >= 0) {
+        e.preventDefault();
+        const conversation = visibleConversations[focusedIndex];
+        if (conversation) {
+          handleSelectConversation(conversation.id);
+          setFocusedIndex(-1);
+        }
+      }
+    };
 
-  const handleOpenUsage = useCallback(() => {
-    openSettings('account');
-  }, [openSettings]);
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [editingId, showSearch, focusedIndex, visibleConversations, handleSelectConversation]);
 
-  // ── Data mapping ─────────────────────────────────────────────────────────
-  const sessions = useMemo<SidebarSession[]>(
-    () => conversations.map(toSidebarSession),
-    [conversations],
+  // Render conversation item using the memoized component
+  const renderConversationItem = useCallback(
+    (conv: ConversationSummary, isKeyboardFocused: boolean) => (
+      <ConversationItem
+        key={conv.id}
+        conv={conv}
+        isActive={conv.id === activeConversationId}
+        isKeyboardFocused={isKeyboardFocused}
+        isSimpleMode={isSimpleMode}
+        showArchived={showArchived}
+        editingId={editingId}
+        editingTitle={editingTitle}
+        projectName={conv.projectId ? projectNameById.get(conv.projectId) : undefined}
+        onSelect={handleSelectConversation}
+        onStartEdit={startEditing}
+        onEditTitleChange={setEditingTitle}
+        onRename={handleRename}
+        onCancelEdit={handleCancelEdit}
+        onOpenCustomInstructions={onOpenCustomInstructions}
+        onTogglePin={togglePinnedConversation}
+        onShare={handleShare}
+        onTransfer={handleTransfer}
+        onForkToByok={handleForkToByok}
+        onExport={handleExportConversation}
+        onExportPdf={handleExportPdf}
+        onArchive={handleArchive}
+        onRestore={handleRestore}
+        onDelete={openDeleteConfirmDialog}
+      />
+    ),
+    [
+      activeConversationId,
+      isSimpleMode,
+      showArchived,
+      editingId,
+      editingTitle,
+      projectNameById,
+      handleSelectConversation,
+      startEditing,
+      handleRename,
+      handleCancelEdit,
+      onOpenCustomInstructions,
+      togglePinnedConversation,
+      handleShare,
+      handleTransfer,
+      handleForkToByok,
+      handleExportConversation,
+      handleExportPdf,
+      handleArchive,
+      handleRestore,
+      openDeleteConfirmDialog,
+    ],
   );
 
-  const sidebarProjects = useMemo<SidebarProject[]>(
-    () => projects.map(toSidebarProject),
-    [projects],
-  );
-
-  // ── Footer slot (desktop-only chrome) ────────────────────────────────────
-  const footerSlot = (
-    <div className="flex items-center gap-1.5 overflow-hidden w-full">
-      {!collapsed && <SimpleModeToggle compact />}
-      <div className="flex-1 min-w-0 overflow-hidden">
-        <UserProfile collapsed={collapsed} />
+  if (collapsed) {
+    return (
+      <div className="w-16 flex flex-col bg-[hsl(var(--card))] border-r border-[hsl(var(--border))] transition-all duration-300 ease-in-out">
+        <div className="p-3 flex flex-col items-center gap-4">
+          <Button
+            onClick={onToggleCollapse}
+            variant="ghost"
+            size="icon"
+            aria-label="Expand sidebar"
+            className="text-[hsl(var(--muted-foreground))]"
+          >
+            <PanelLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            onClick={handleNewChat}
+            variant="ghost"
+            size="icon"
+            aria-label="New chat"
+            className="text-[hsl(var(--muted-foreground))]"
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+          <Button
+            onClick={() => {
+              if (onToggleCollapse) onToggleCollapse();
+              setShowSearch(true);
+            }}
+            variant="ghost"
+            size="icon"
+            aria-label="Search conversations"
+            className="text-[hsl(var(--muted-foreground))]"
+          >
+            <Search className="h-4 w-4" />
+          </Button>
+          <Button
+            onClick={() => {
+              if (onToggleCollapse) onToggleCollapse();
+              setActiveView('projects');
+            }}
+            variant="ghost"
+            size="icon"
+            aria-label="Projects"
+            className="text-[hsl(var(--muted-foreground))]"
+          >
+            <FolderOpen className="h-4 w-4" />
+          </Button>
+          <Button
+            onClick={() => {
+              if (onToggleCollapse) onToggleCollapse();
+              setActiveView('skills');
+            }}
+            variant="ghost"
+            size="icon"
+            aria-label="Skills"
+            className="text-[hsl(var(--muted-foreground))]"
+          >
+            <Sparkles className="h-4 w-4" />
+          </Button>
+          {/* Mode dot — collapsed state shows only the colored dot */}
+          <div
+            title={
+              mode === 'local'
+                ? formatChatExecutionModeLabel('local_only')
+                : formatChatExecutionModeLabel('cloud_managed')
+            }
+            className={cn(
+              'w-2 h-2 rounded-full',
+              mode === 'local' ? 'bg-emerald-400' : 'bg-blue-400',
+            )}
+          />
+        </div>
       </div>
-    </div>
-  );
-
-  // ── Header slot (incognito toggle) ────────────────────────────────────────
-  const headerSlot = (
-    <IncognitoToggle isIncognito={isIncognito} onToggle={() => setIsIncognito((prev) => !prev)} />
-  );
+    );
+  }
 
   return (
     <>
@@ -391,9 +987,103 @@ export function Sidebar({
         onClose={() => setShareDialog((prev) => ({ ...prev, open: false }))}
       />
 
-      {/* Resize handle — rendered outside SharedSidebar so it can overlap the border */}
-      {onResize && !collapsed && (
-        <div className="relative" style={{ width: 0, height: '100%' }}>
+      {/* Transfer Conversation Dialog */}
+      {transferTarget && (
+        <TransferDialog
+          conversationId={transferTarget.id}
+          conversationTitle={transferTarget.title}
+          direction={mode === 'local' ? 'local_to_cloud' : 'cloud_to_local'}
+          localDbId={transferTarget.localDbId}
+          onClose={() => setTransferTarget(null)}
+        />
+      )}
+      {handoffTarget && (
+        <LocalByokHandoffDialog
+          conversationId={handoffTarget.id}
+          conversationTitle={handoffTarget.title}
+          onClose={() => setHandoffTarget(null)}
+        />
+      )}
+
+      {}
+      <AnimatePresence>
+        {showSearch && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 bg-black/50 backdrop-blur-xs"
+            onClick={() => setShowSearch(false)}
+          >
+            <motion.div
+              initial={{ scale: 0.95, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.95, opacity: 0 }}
+              className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-2xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="bg-[hsl(var(--card))] rounded-xl shadow-2xl overflow-hidden">
+                <div className="flex items-center gap-3 px-5 py-4 border-b border-[hsl(var(--border))]">
+                  <Search className="h-5 w-5 text-[hsl(var(--muted-foreground))]" />
+                  <Input
+                    autoFocus
+                    placeholder="Search conversations..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="flex-1 border-0 bg-transparent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden"
+                  />
+                  <kbd className="px-2 py-1 text-xs bg-[hsl(var(--muted))] text-[hsl(var(--muted-foreground))] rounded">
+                    ESC
+                  </kbd>
+                </div>
+                <ScrollArea className="max-h-96">
+                  <div className="p-2">
+                    {filtered.slice(0, 10).map((conv) => (
+                      <button
+                        type="button"
+                        key={conv.id}
+                        onClick={() => {
+                          selectConversationFn(conv.id);
+                          setActiveView('chat');
+                          setShowSearch(false);
+                          setSearchQuery('');
+                        }}
+                        className={cn(
+                          'w-full text-left px-3 py-2 rounded-lg transition-colors',
+                          conv.id === activeConversationId
+                            ? 'bg-primary/10'
+                            : 'hover:bg-[hsl(var(--accent))]',
+                        )}
+                      >
+                        <div className="font-medium text-sm">{conv.title}</div>
+                        {conv.lastMessage && (
+                          <div className="text-xs text-[hsl(var(--muted-foreground))] truncate mt-1">
+                            {conv.lastMessage}
+                          </div>
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                </ScrollArea>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <div
+        className={cn(
+          'flex flex-col bg-[hsl(var(--card))] border-r border-[hsl(var(--border))] transition-all duration-300 ease-in-out relative',
+          isIncognito && 'border-purple-500/30',
+          className,
+        )}
+        style={{ width: width }}
+      >
+        {/* Incognito mode subtle top stripe */}
+        {isIncognito && (
+          <div className="absolute inset-x-0 top-0 h-0.5 bg-gradient-to-r from-transparent via-purple-500/60 to-transparent pointer-events-none z-10" />
+        )}
+        {onResize && !collapsed && (
           <ResizeHandle
             width={width}
             onResize={onResize}
@@ -401,45 +1091,334 @@ export function Sidebar({
             minWidth={200}
             maxWidth={400}
           />
+        )}
+        {}
+        <div className="p-4 border-b border-[hsl(var(--border))]">
+          <div className="flex items-center justify-between mb-3">
+            <Button
+              onClick={onToggleCollapse}
+              variant="ghost"
+              size="icon"
+              className="text-[hsl(var(--muted-foreground))]"
+            >
+              <PanelLeft className="h-4 w-4" />
+            </Button>
+            <div className="flex items-center gap-1.5">
+              <IncognitoToggle
+                isIncognito={isIncognito}
+                onToggle={() => setIsIncognito((prev) => !prev)}
+              />
+              <Button
+                onClick={handleNewChat}
+                className={cn(
+                  'flex items-center gap-2 transition-colors',
+                  isIncognito
+                    ? 'bg-purple-500/15 hover:bg-purple-500/25 text-purple-600 dark:text-purple-400 ring-1 ring-purple-500/30'
+                    : 'bg-[hsl(var(--muted))] hover:bg-[hsl(var(--accent))] text-[hsl(var(--foreground))]',
+                )}
+              >
+                <Plus className="h-4 w-4" />
+                New Chat
+              </Button>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowSearch(true)}
+            className="w-full flex items-center gap-2 px-3 py-2 bg-[hsl(var(--muted))] rounded-lg text-sm text-[hsl(var(--foreground))] hover:bg-[hsl(var(--accent))] transition-colors"
+          >
+            <Search className="h-4 w-4" />
+            <span>Search</span>
+            <div className="ml-auto flex items-center gap-1">
+              <kbd className="px-1.5 py-0.5 text-xs bg-[hsl(var(--card))] rounded">
+                {modKeySymbol}
+              </kbd>
+              <kbd className="px-1.5 py-0.5 text-xs bg-[hsl(var(--card))] rounded">K</kbd>
+            </div>
+          </button>
         </div>
-      )}
 
-      {/* The shared pure-presentation sidebar */}
-      <SharedSidebar
-        className={cn(isIncognito && 'border-purple-500/30', className)}
-        sessions={sessions}
-        activeSessionId={activeConversationId ?? undefined}
-        projects={sidebarProjects}
-        selectedProjectFilter={selectedProjectFilter}
-        collapsed={collapsed}
-        width={width}
-        isMobile={isMobile}
-        isSimpleMode={isSimpleMode}
-        mode={mode === 'local' ? 'local' : 'cloud'}
-        budgetPercent={clampedBudgetPct}
-        showUsageWidget={showUsageWidget}
-        // handlers
-        onNewChat={handleNewChat}
-        onToggleCollapse={onToggleCollapse}
-        onSelectProjectFilter={setSelectedProjectFilter}
-        onOpenProjects={handleOpenProjects}
-        onOpenSkills={handleOpenSkills}
-        onModeClick={isTauri ? handleModeClick : undefined}
-        onOpenUsage={handleOpenUsage}
-        // per-session handlers
-        onSelect={handleSelect}
-        onRename={handleRename}
-        onDelete={handleDelete}
-        onTogglePin={handleTogglePin}
-        onArchive={handleArchive}
-        onRestore={handleRestore}
-        onShare={handleShare}
-        onOpenCustomInstructions={onOpenCustomInstructions}
-        // slots
-        headerSlot={headerSlot}
-        footerSlot={footerSlot}
-        navItems={isSimpleMode ? [] : undefined}
-      />
+        {/* Minimal navigation */}
+        {!collapsed && !isSimpleMode && (
+          <div className="px-2 py-1.5 border-b border-[hsl(var(--border))] space-y-0.5">
+            {[
+              {
+                id: 'projects',
+                label: 'Projects',
+                icon: FolderOpen,
+                onClick: () => setActiveView('projects'),
+                isActive: activeView === 'projects',
+              },
+              {
+                id: 'skills',
+                label: 'Skills',
+                icon: Sparkles,
+                onClick: () => setActiveView('skills'),
+                isActive: activeView === 'skills',
+              },
+            ].map(({ id, label, icon: Icon, onClick, isActive }) => (
+              <button
+                key={id}
+                type="button"
+                onClick={onClick}
+                className={cn(
+                  'w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm font-medium transition-colors',
+                  'focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden',
+                  isActive
+                    ? 'bg-white/10 text-[hsl(var(--foreground))]'
+                    : 'text-[hsl(var(--muted-foreground))] hover:bg-white/5 hover:text-[hsl(var(--foreground))]',
+                )}
+              >
+                <Icon className="h-4 w-4 shrink-0" />
+                <span>{label}</span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Compact filter bar: project filter + archive toggle */}
+        {!collapsed && !isSimpleMode && (
+          <div className="px-3 py-2 flex items-center gap-1">
+            {/* Project filter dropdown */}
+            {projects.length > 0 && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className={cn(
+                      'flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-lg transition-colors',
+                      selectedProjectFilter
+                        ? 'bg-blue-500/10 text-blue-600 dark:text-blue-400'
+                        : 'text-muted-foreground hover:bg-surface-hover',
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        'w-4 h-4 flex items-center justify-center rounded',
+                        selectedProjectFilter
+                          ? 'text-blue-500'
+                          : 'bg-[hsl(var(--muted))] text-[hsl(var(--muted-foreground))]',
+                      )}
+                      style={
+                        selectedProject?.color
+                          ? {
+                              backgroundColor: `${selectedProject.color}20`,
+                              color: selectedProject.color,
+                            }
+                          : undefined
+                      }
+                    >
+                      <FolderOpen className="w-3 h-3" />
+                    </span>
+                    <span className="truncate max-w-[100px]">{selectedProject?.name || 'All'}</span>
+                    <ChevronDown className="w-3 h-3 text-[hsl(var(--muted-foreground))]" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  align="start"
+                  className="w-56 bg-[hsl(var(--popover))] border-[hsl(var(--border))]"
+                >
+                  <DropdownMenuItem
+                    onClick={() => setSelectedProjectFilter(null)}
+                    className={cn(
+                      'text-[hsl(var(--popover-foreground))]',
+                      !selectedProjectFilter && 'bg-[hsl(var(--accent))]',
+                    )}
+                  >
+                    <MessageSquare className="w-4 h-4 mr-2" />
+                    All Conversations
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator className="bg-[hsl(var(--border))]" />
+                  {projects.map((project) => (
+                    <DropdownMenuItem
+                      key={project.id}
+                      onClick={() => setSelectedProjectFilter(project.id)}
+                      className={cn(
+                        'text-[hsl(var(--popover-foreground))]',
+                        selectedProjectFilter === project.id && 'bg-[hsl(var(--accent))]',
+                      )}
+                    >
+                      <span
+                        className="w-4 h-4 rounded mr-2 flex items-center justify-center"
+                        style={{ backgroundColor: project.color || '#3b82f6' }}
+                      >
+                        <Layers className="w-2.5 h-2.5 text-white" />
+                      </span>
+                      <span className="truncate">{project.name}</span>
+                      <span className="ml-auto text-xs text-[hsl(var(--muted-foreground))]">
+                        {conversations.filter((c) => c.projectId === project.id).length}
+                      </span>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+
+            {/* Clear project filter */}
+            {selectedProjectFilter && (
+              <Button
+                onClick={() => setSelectedProjectFilter(null)}
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 text-[hsl(var(--muted-foreground))] hover:text-[hsl(var(--foreground))]"
+                title="Clear filter"
+              >
+                <X className="w-3 h-3" />
+              </Button>
+            )}
+
+            {/* Spacer */}
+            <div className="flex-1" />
+
+            {/* Archive toggle (icon button) */}
+            {archivedConversations.length > 0 && (
+              <Button
+                onClick={() => setShowArchived(!showArchived)}
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  'h-7 w-7',
+                  showArchived
+                    ? 'text-amber-600 dark:text-amber-400'
+                    : 'text-[hsl(var(--muted-foreground))]',
+                )}
+                title={showArchived ? 'Show active' : `Archived (${archivedConversations.length})`}
+              >
+                <Archive className="w-3.5 h-3.5" />
+              </Button>
+            )}
+          </div>
+        )}
+
+        {}
+        <ScrollArea className="flex-1">
+          <div className="p-2">
+            {}
+            {pinnedConversations.length > 0 && (
+              <div className="mb-6">
+                <div className="px-3 mb-2 text-xs font-semibold text-[hsl(var(--muted-foreground))] uppercase tracking-wider flex items-center gap-1">
+                  <Pin className="w-3 h-3" /> Pinned
+                </div>
+                {pinnedConversations.map((conv) => {
+                  const globalIndex = visibleConversations.findIndex((c) => c.id === conv.id);
+                  return renderConversationItem(conv, globalIndex === focusedIndex);
+                })}
+              </div>
+            )}
+
+            {}
+            {Array.from(groupedConversations.entries()).map(([group, convs]) => (
+              <div key={group} className="mb-4">
+                <button
+                  type="button"
+                  onClick={() => toggleGroup(group)}
+                  aria-expanded={expandedGroups.has(group)}
+                  aria-controls={`conversation-group-${group}`}
+                  className="w-full flex items-center gap-2 px-2 py-1 text-xs font-medium text-[hsl(var(--muted-foreground))] hover:text-[hsl(var(--foreground))] transition-colors"
+                >
+                  <ChevronRight
+                    className={cn(
+                      'h-3 w-3 transition-transform',
+                      expandedGroups.has(group) && 'rotate-90',
+                    )}
+                  />
+                  <span className="flex items-center gap-1">
+                    {group === 'today' && <Calendar className="h-3 w-3" />}
+                    {group === 'yesterday' && <Clock className="h-3 w-3" />}
+                    {TEMPORAL_LABELS[group]}
+                  </span>
+                  <span className="ml-auto text-[hsl(var(--muted-foreground))]">
+                    ({convs.length})
+                  </span>
+                </button>
+
+                <AnimatePresence>
+                  {expandedGroups.has(group) && (
+                    <motion.div
+                      id={`conversation-group-${group}`}
+                      initial={{ height: 0, opacity: 0 }}
+                      animate={{ height: 'auto', opacity: 1 }}
+                      exit={{ height: 0, opacity: 0 }}
+                      transition={{ duration: 0.2 }}
+                      className="mt-1 space-y-1"
+                    >
+                      {convs.map((conv) => {
+                        const globalIndex = visibleConversations.findIndex((c) => c.id === conv.id);
+                        return renderConversationItem(conv, globalIndex === focusedIndex);
+                      })}
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+            ))}
+          </div>
+        </ScrollArea>
+
+        {/* Bottom bar: usage widget (when > 50%) + SimpleModeToggle + UserProfile + NotificationCenter */}
+        <div className="mt-auto border-t border-[hsl(var(--border))] px-3 py-2.5 space-y-2">
+          {/* Sidebar usage widget — only visible when budget is enabled and > 50% used */}
+          {!collapsed && showUsageWidget && (
+            <button
+              type="button"
+              onClick={() => openSettings('account')}
+              title={`${Math.round(clampedBudgetPct)}% of token budget used — click to manage`}
+              className="w-full group flex items-center gap-2 px-1 py-1 rounded-md hover:bg-white/5 transition-colors"
+            >
+              <div className="flex-1 h-1 rounded-full bg-white/10 overflow-hidden">
+                <div
+                  className={cn(
+                    'h-full rounded-full transition-all duration-300',
+                    clampedBudgetPct >= 95
+                      ? 'bg-red-500'
+                      : clampedBudgetPct >= 80
+                        ? 'bg-amber-500'
+                        : 'bg-blue-500',
+                  )}
+                  style={{ width: `${clampedBudgetPct}%` }}
+                />
+              </div>
+              <span className="text-[10px] tabular-nums text-muted-foreground group-hover:text-foreground transition-colors shrink-0">
+                {Math.round(clampedBudgetPct)}%
+              </span>
+            </button>
+          )}
+          <div className="flex items-center gap-1.5 overflow-hidden">
+            {!collapsed && <SimpleModeToggle compact />}
+            <div className="flex-1 min-w-0 overflow-hidden">
+              <UserProfile collapsed={collapsed} />
+            </div>
+            {/* Mode toggle pill — expanded state (hidden in web mode, always cloud) */}
+            {!collapsed && isTauri && (
+              <button
+                type="button"
+                onClick={() => {
+                  if (mode === 'local') {
+                    void openExternalUrl('https://agiworkforce.com/waitlist');
+                    return;
+                  }
+                  setMode('local');
+                }}
+                title={
+                  mode === 'local'
+                    ? 'Join Cloud Managed waitlist'
+                    : `Switch to ${formatChatExecutionModeLabel('local_only')}`
+                }
+                className={cn(
+                  'px-2 py-0.5 rounded-full text-[10px] font-medium uppercase tracking-wider shrink-0 transition-colors cursor-pointer',
+                  mode === 'local'
+                    ? 'bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30'
+                    : 'bg-blue-500/20 text-blue-400 hover:bg-blue-500/30',
+                )}
+              >
+                {mode === 'local'
+                  ? formatChatExecutionModeLabel('local_only')
+                  : formatChatExecutionModeLabel('cloud_managed')}
+              </button>
+            )}
+            {!collapsed && <NotificationCenter className="shrink-0" />}
+          </div>
+        </div>
+      </div>
     </>
   );
 }

--- a/apps/desktop/src/features/chat/Sidebar.tsx
+++ b/apps/desktop/src/features/chat/Sidebar.tsx
@@ -1,56 +1,55 @@
-import { AnimatePresence, motion } from 'framer-motion';
+/**
+ * Desktop Sidebar — wrapper around the shared @agiworkforce/ui <Sidebar>.
+ *
+ * This file owns all desktop-specific logic:
+ *   - Store reads (chatStore / projectStore / billingUsageStore / appModeStore / simpleModeStore)
+ *   - Desktop-only dialogs (ShareConversationDialog, AlertDialog for delete confirm)
+ *   - Desktop footer chrome (UserProfile, SimpleModeToggle, mode pill)
+ *   - Incognito toggle header slot
+ *
+ * Pure rendering is delegated to @agiworkforce/ui <Sidebar> — the same component
+ * that the web surface mounts. Mapping: ConversationSummary → SidebarSession,
+ * Project → SidebarProject.
+ *
+ * Trust-boundary affordances (TransferDialog, LocalByokHandoffDialog, export PDF/MD)
+ * are preserved as dialog state + handlers here; they are desktop-only and will be
+ * re-connected to a future shared sidebar extension point (e.g. a "More actions"
+ * context menu) in a follow-up. They are NOT exposed through the shared component
+ * so the web surface never sees them.
+ *
+ * SidebarFeaturesPopover is intentionally not re-mounted (removed from live sidebar —
+ * features accessible via chat / Cmd+K, per comment at original Sidebar.tsx line 68).
+ */
+import type { ProjectAccentColor } from '@agiworkforce/types';
 import {
-  Archive,
-  ArchiveRestore,
-  Calendar,
-  ChevronDown,
-  ChevronRight,
-  PanelLeft,
-  Clock,
-  Cloud,
-  Download,
-  FileText,
-  FolderOpen,
-  KeyRound,
-  Layers,
-  Link2,
-  MessageSquare,
-  Pin,
-  PinOff,
-  Plus,
-  Search,
-  Sparkles,
-  Trash2,
-  X,
-} from 'lucide-react';
-import { toast } from 'sonner';
-import { formatChatExecutionModeLabel, formatPrivacyModeLabel } from '@agiworkforce/types';
-import { useCallback, useEffect, useMemo, useRef, useState, memo } from 'react';
+  Sidebar as SharedSidebar,
+  type SidebarSession,
+  type SidebarProject,
+} from '@agiworkforce/ui';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
+import { toast } from 'sonner';
 import { cn } from '../../lib/utils';
 import {
   useChatStore,
   selectConversations,
   selectActiveConversationId,
-  selectActiveView,
-  uuidToDbId,
   type ConversationSummary,
 } from '../../stores/chat/chatStore';
 import { useProjectStore, selectActiveProjects } from '../../stores/projectStore';
 import { cloudAccountAuth } from '../../services/cloudAccountAuth';
 import { resetInFlightChatState } from '../../lib/newChatReset';
 import { UserProfile } from '@/features/layout/UserProfile';
-import { Button } from '@/components/ui/Button';
-import { Input } from '@/components/ui/Input';
 import { ResizeHandle } from '@/components/ui/ResizeHandle';
-import { ScrollArea } from '@/components/ui/ScrollArea';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/DropdownMenu';
+import { useSimpleModeStore, selectIsSimpleMode } from '../../stores/ui';
+import { SimpleModeToggle } from '@/features/simple-mode';
+import { ShareConversationDialog } from './ShareConversationDialog';
+import { IncognitoToggle } from './IncognitoToggle';
+import { isTauri } from '../../lib/tauri-mock';
+import { useBillingUsageStore, selectBudgetPercentage } from '../../stores/billingUsage';
+import { useSettingsDialogStore } from '../../stores/settingsDialogStore';
+import { useAppModeStore, selectMode } from '../../stores/appModeStore';
+import { openExternalUrl } from '../../utils/navigation';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -61,22 +60,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/AlertDialog';
-import { useSimpleModeStore, selectIsSimpleMode } from '../../stores/ui';
-import { SimpleModeToggle } from '@/features/simple-mode';
-import { NotificationCenter } from '@/features/notifications';
-import { ShareConversationDialog } from './ShareConversationDialog';
-// SidebarFeaturesPopover removed — features accessible via chat or Cmd+K
-import { TransferDialog } from './TransferDialog';
-import { LocalByokHandoffDialog } from './LocalByokHandoffDialog';
-import { IncognitoToggle } from './IncognitoToggle';
-import { save } from '@tauri-apps/plugin-dialog';
-import { invoke, isTauri } from '../../lib/tauri-mock';
-import { useBillingUsageStore, selectBudgetPercentage } from '../../stores/billingUsage';
-import { useSettingsDialogStore } from '../../stores/settingsDialogStore';
-import { useAppModeStore, selectMode } from '../../stores/appModeStore';
-import { openExternalUrl } from '../../utils/navigation';
 
-interface SidebarProps {
+export interface SidebarProps {
   className?: string;
   onOpenCustomInstructions?: (conversationId: string) => void;
   onNewChat?: () => void | Promise<void>;
@@ -86,6 +71,7 @@ interface SidebarProps {
   onCollapsedChange?: (collapsed: boolean) => void;
   width?: number;
   onResize?: (width: number) => void;
+  /** Unused legacy props — kept for backwards compat so AppLayout compiles. */
   onOpenResearch?: () => void;
   onOpenRewind?: () => void;
   onOpenCollaboration?: () => void;
@@ -98,300 +84,42 @@ interface SidebarProps {
   onOpenCanvas?: () => void;
 }
 
-type TemporalGroup = 'today' | 'yesterday' | 'thisWeek' | 'last7Days' | 'last30Days' | 'older';
+// ── Mapping helpers ──────────────────────────────────────────────────────────
 
-/**
- * Memoized conversation item component to prevent unnecessary re-renders.
- * PERFORMANCE OPTIMIZATION: Each conversation item in the sidebar can trigger
- * re-renders when the parent state changes. By memoizing this component,
- * we only re-render when the specific conversation data changes.
- */
-interface ConversationItemProps {
-  conv: ConversationSummary;
-  isActive: boolean;
-  isKeyboardFocused: boolean;
-  isSimpleMode: boolean;
-  showArchived: boolean;
-  editingId: string | null;
-  editingTitle: string;
-  /** Project name for attribution badge — undefined when no project assigned */
-  projectName?: string;
-  onSelect: (id: string) => void;
-  onStartEdit: (conv: ConversationSummary) => void;
-  onEditTitleChange: (title: string) => void;
-  onRename: (id: string) => void;
-  onCancelEdit: () => void;
-  onOpenCustomInstructions?: (id: string) => void;
-  onTogglePin: (id: string) => void;
-  onShare: (id: string, title: string) => void;
-  onTransfer: (id: string, title: string) => void;
-  onForkToByok: (id: string, title: string) => void;
-  onExport: (id: string, title: string) => void;
-  onExportPdf: (id: string, title: string) => void;
-  onArchive: (id: string) => void;
-  onRestore: (id: string) => void;
-  onDelete: (id: string, title: string) => void;
+function toSidebarSession(conv: ConversationSummary): SidebarSession {
+  return {
+    id: conv.id,
+    title: conv.title || 'Untitled',
+    updatedAt: conv.updatedAt,
+    lastMessage: conv.lastMessage,
+    pinned: conv.pinned,
+    archived: conv.archived,
+    projectId: conv.projectId,
+    incognito: conv.incognito,
+    hasCustomInstructions: Boolean(conv.customInstructions),
+  };
 }
 
-const ConversationItem = memo<ConversationItemProps>(
-  ({
-    conv,
-    isActive,
-    isKeyboardFocused,
-    isSimpleMode,
-    showArchived,
-    editingId,
-    editingTitle,
-    projectName,
-    onSelect,
-    onStartEdit,
-    onEditTitleChange,
-    onRename,
-    onCancelEdit,
-    onOpenCustomInstructions,
-    onTogglePin,
-    onShare,
-    onTransfer,
-    onForkToByok,
-    onExport,
-    onExportPdf,
-    onArchive,
-    onRestore,
-    onDelete,
-  }) => {
-    const isEditing = editingId === conv.id;
-
-    return (
-      <div
-        className={cn(
-          'group relative rounded-lg transition-all mb-1',
-          isActive ? 'bg-teal-100 dark:bg-teal-900/30' : 'hover:bg-[hsl(var(--accent))]',
-          isKeyboardFocused && 'ring-2 ring-teal-500 ring-offset-2',
-          conv.incognito && 'ring-1 ring-purple-500/20',
-        )}
-      >
-        {isEditing ? (
-          <Input
-            autoFocus
-            value={editingTitle}
-            onChange={(e) => onEditTitleChange(e.target.value)}
-            onBlur={() => onRename(conv.id)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') onRename(conv.id);
-              if (e.key === 'Escape') onCancelEdit();
-            }}
-            className="w-full px-3 py-2 text-sm"
-          />
-        ) : (
-          <div className="flex items-center">
-            <button
-              type="button"
-              onClick={() => onSelect(conv.id)}
-              onDoubleClick={() => onStartEdit(conv)}
-              aria-current={isActive ? 'page' : undefined}
-              className="flex-1 text-left px-3 py-2 overflow-hidden"
-            >
-              <div className="font-medium text-sm truncate">{conv.title || 'Untitled'}</div>
-              {conv.lastMessage && (
-                <div className="text-xs text-[hsl(var(--muted-foreground))] truncate">
-                  {conv.lastMessage}
-                </div>
-              )}
-              {/* Project attribution badge — shown when conversation belongs to a project */}
-              {projectName && (
-                <div className="mt-0.5 text-[10px] text-[hsl(var(--muted-foreground))] truncate">
-                  in{' '}
-                  <span className="font-medium text-[hsl(var(--foreground))]/60">
-                    {projectName}
-                  </span>
-                </div>
-              )}
-            </button>
-
-            {/* Conversation action buttons - simplified in simple mode */}
-            <div className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity flex items-center gap-0.5 pr-2">
-              {/* Only show delete in simple mode, show all actions in advanced mode */}
-              {!isSimpleMode && (
-                <>
-                  <Button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onOpenCustomInstructions?.(conv.id);
-                    }}
-                    variant="ghost"
-                    size="icon"
-                    className={cn(
-                      'h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-amber-500',
-                      conv.customInstructions && 'text-amber-500',
-                    )}
-                    title={
-                      conv.customInstructions
-                        ? 'Edit custom instructions'
-                        : 'Add custom instructions'
-                    }
-                  >
-                    <Sparkles className="h-3 w-3" />
-                  </Button>
-                  <Button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onTogglePin(conv.id);
-                    }}
-                    variant="ghost"
-                    size="icon"
-                    className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-teal-500"
-                    title={conv.pinned ? 'Unpin' : 'Pin'}
-                  >
-                    {conv.pinned ? <PinOff className="h-3 w-3" /> : <Pin className="h-3 w-3" />}
-                  </Button>
-                  <Button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onShare(conv.id, conv.title || 'Untitled');
-                    }}
-                    variant="ghost"
-                    size="icon"
-                    className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-teal-500"
-                    title="Share conversation"
-                  >
-                    <Link2 className="h-3 w-3" />
-                  </Button>
-                  <Button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onTransfer(conv.id, conv.title || 'Untitled');
-                    }}
-                    variant="ghost"
-                    size="icon"
-                    className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-blue-500"
-                    title="Transfer conversation"
-                  >
-                    <Cloud className="h-3 w-3" />
-                  </Button>
-                  <Button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onForkToByok(conv.id, conv.title || 'Untitled');
-                    }}
-                    variant="ghost"
-                    size="icon"
-                    className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-amber-500"
-                    title={`Fork to ${formatPrivacyModeLabel('byok')}`}
-                  >
-                    <KeyRound className="h-3 w-3" />
-                  </Button>
-                  <Button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onExport(conv.id, conv.title || 'Untitled');
-                    }}
-                    variant="ghost"
-                    size="icon"
-                    className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-blue-500"
-                    title="Export to Markdown"
-                  >
-                    <Download className="h-3 w-3" />
-                  </Button>
-                  <Button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onExportPdf(conv.id, conv.title || 'Untitled');
-                    }}
-                    variant="ghost"
-                    size="icon"
-                    className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-red-500"
-                    title="Export as PDF"
-                  >
-                    <FileText className="h-3 w-3" />
-                  </Button>
-                  {showArchived ? (
-                    <Button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onRestore(conv.id);
-                      }}
-                      variant="ghost"
-                      size="icon"
-                      className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-emerald-500"
-                      title="Restore from archive"
-                    >
-                      <ArchiveRestore className="h-3 w-3" />
-                    </Button>
-                  ) : (
-                    <Button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onArchive(conv.id);
-                      }}
-                      variant="ghost"
-                      size="icon"
-                      className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-amber-500"
-                      title="Archive"
-                    >
-                      <Archive className="h-3 w-3" />
-                    </Button>
-                  )}
-                </>
-              )}
-              <Button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDelete(conv.id, conv.title || 'Untitled');
-                }}
-                variant="ghost"
-                size="icon"
-                className="h-6 w-6 text-[hsl(var(--muted-foreground))] hover:text-red-500"
-                title="Delete"
-              >
-                <Trash2 className="h-3 w-3" />
-              </Button>
-            </div>
-          </div>
-        )}
-      </div>
-    );
-  },
-);
-
-ConversationItem.displayName = 'ConversationItem';
-
-const TEMPORAL_LABELS: Record<TemporalGroup, string> = {
-  today: 'Today',
-  yesterday: 'Yesterday',
-  thisWeek: 'This Week',
-  last7Days: 'Last 7 Days',
-  last30Days: 'Last 30 Days',
-  older: 'Older',
-};
-
-function getTemporalGroup(date: Date): TemporalGroup {
-  const now = new Date();
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const yesterday = new Date(today);
-  yesterday.setDate(yesterday.getDate() - 1);
-  const thisWeekStart = new Date(today);
-  thisWeekStart.setDate(thisWeekStart.getDate() - today.getDay());
-  const sevenDaysAgo = new Date(today);
-  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-  const thirtyDaysAgo = new Date(today);
-  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-
-  const conversationDate = new Date(date);
-
-  if (conversationDate >= today) {
-    return 'today';
-  } else if (conversationDate >= yesterday && conversationDate < today) {
-    return 'yesterday';
-  } else if (conversationDate >= thisWeekStart && conversationDate < yesterday) {
-    return 'thisWeek';
-  } else if (conversationDate >= sevenDaysAgo) {
-    return 'last7Days';
-  } else if (conversationDate >= thirtyDaysAgo) {
-    return 'last30Days';
-  } else {
-    return 'older';
-  }
+function toSidebarProject(p: {
+  id: string;
+  name: string;
+  color?: string;
+  accentColor?: ProjectAccentColor | null;
+  iconEmoji?: string | null;
+  conversationIds?: string[];
+}): SidebarProject {
+  return {
+    id: p.id,
+    name: p.name,
+    color: p.color,
+    // ProjectAccentColor is a string-literal union — safe to widen to string
+    accentColor: (p.accentColor as string | undefined) ?? undefined,
+    iconEmoji: p.iconEmoji ?? undefined,
+    conversationCount: p.conversationIds?.length,
+  };
 }
+
+// ── Main component ───────────────────────────────────────────────────────────
 
 export function Sidebar({
   className,
@@ -403,6 +131,7 @@ export function Sidebar({
   onCollapsedChange = () => {},
   width = 260,
   onResize,
+  // Legacy props — accepted but not forwarded.
   onOpenResearch: _onOpenResearch,
   onOpenRewind: _onOpenRewind,
   onOpenCollaboration: _onOpenCollaboration,
@@ -414,221 +143,64 @@ export function Sidebar({
   onOpenMcpBundles: _onOpenMcpBundles,
   onOpenCanvas: _onOpenCanvas,
 }: SidebarProps) {
-  // Platform-aware modifier key: ⌘ on Mac, Ctrl on Windows/Linux
-  const modKeySymbol =
-    typeof navigator !== 'undefined' && navigator.platform.includes('Mac') ? '⌘' : 'Ctrl';
-
-  // Local/Managed mode — drives the indicator pill in the footer
+  // ── Store reads ──────────────────────────────────────────────────────────
   const mode = useAppModeStore(selectMode);
   const setMode = useAppModeStore((s) => s.setMode);
 
-  // Usage data for the sidebar widget (only shown when > 50%)
   const budgetPct = useBillingUsageStore(selectBudgetPercentage);
   const budgetEnabled = useBillingUsageStore((s) => s.budget.enabled);
   const openSettings = useSettingsDialogStore((s) => s.openSettings);
   const clampedBudgetPct = Math.min(Math.max(budgetPct, 0), 100);
   const showUsageWidget = budgetEnabled && clampedBudgetPct > 50;
 
-  // Migration: All store hooks now use useChatStore (modular store) instead of useUnifiedChatStore
-  // Using exported selectors for optimal re-render performance
   const conversations = useChatStore(selectConversations);
   const activeConversationId = useChatStore(selectActiveConversationId);
-  const activeView = useChatStore(selectActiveView);
 
-  // Simple mode state - hide advanced features
   const isSimpleMode = useSimpleModeStore(selectIsSimpleMode);
 
-  // Conversation actions - renamed selectConversation to avoid conflict with selector
   const selectConversationFn = useChatStore((state) => state.selectConversation);
   const renameConversation = useChatStore((state) => state.renameConversation);
   const deleteConversation = useChatStore((state) => state.deleteConversation);
   const togglePinnedConversation = useChatStore((state) => state.togglePinnedConversation);
   const archiveConversation = useChatStore((state) => state.archiveConversation);
   const restoreConversation = useChatStore((state) => state.restoreConversation);
-  const exportConversationToMarkdown = useChatStore((state) => state.exportConversationToMarkdown);
   const createConversation = useChatStore((state) => state.createConversation);
   const setActiveView = useChatStore((state) => state.setActiveView);
   const ensureActiveConversation = useChatStore((state) => state.ensureActiveConversation);
-  // Message loading functions
   const messagesByConversation = useChatStore((state) => state.messagesByConversation);
   const loadConversationMessages = useChatStore((state) => state.loadConversationMessages);
 
-  const handleExportConversation = useCallback(
-    (id: string, title: string) => {
-      const markdown = exportConversationToMarkdown(id);
-      if (!markdown) {
-        toast.error('No messages to export');
-        return;
-      }
+  const projects = useProjectStore(useShallow(selectActiveProjects));
+  const activeProjectId = useProjectStore((state) => state.activeProjectId);
 
-      // Create and trigger download
-      const blob = new Blob([markdown], { type: 'text/markdown' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${title.replace(/[^a-z0-9]/gi, '_').toLowerCase()}_conversation.md`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      setTimeout(() => URL.revokeObjectURL(url), 1000);
-
-      toast.success('Conversation exported');
-    },
-    [exportConversationToMarkdown],
-  );
-
-  const handleExportPdf = useCallback(async (id: string, title: string) => {
-    if (!isTauri) {
-      toast.info('PDF export requires the desktop app');
-      return;
-    }
-    try {
-      const safeName = title
-        .replace(/[^a-zA-Z0-9 _-]/g, '')
-        .replace(/\s+/g, '-')
-        .slice(0, 60);
-      const filePath = await save({
-        defaultPath: `${safeName || 'conversation'}.pdf`,
-        filters: [{ name: 'PDF', extensions: ['pdf'] }],
-      });
-      if (filePath) {
-        await invoke<string>('conversation_export_pdf', {
-          conversationId: id,
-          outputPath: filePath,
-        });
-        toast.success('Conversation exported as PDF');
-      }
-    } catch {
-      toast.error('Failed to export conversation as PDF');
-    }
-  }, []);
-
+  // ── Local UI state ───────────────────────────────────────────────────────
   const [isIncognito, setIsIncognito] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editingTitle, setEditingTitle] = useState('');
-  const [showSearch, setShowSearch] = useState(false);
-  const [showArchived, setShowArchived] = useState(false);
   const [selectedProjectFilter, setSelectedProjectFilter] = useState<string | null>(null);
-  const [expandedGroups, setExpandedGroups] = useState<Set<TemporalGroup>>(
-    new Set(['today', 'yesterday', 'thisWeek']),
-  );
-  const [focusedIndex, setFocusedIndex] = useState<number>(-1);
+
   const [deleteConfirmDialog, setDeleteConfirmDialog] = useState<{
     open: boolean;
     conversationId: string;
     conversationTitle: string;
   }>({ open: false, conversationId: '', conversationTitle: '' });
+
   const [shareDialog, setShareDialog] = useState<{
     open: boolean;
     conversationId: string;
     conversationTitle: string;
   }>({ open: false, conversationId: '', conversationTitle: '' });
 
-  const [transferTarget, setTransferTarget] = useState<{
-    id: string;
-    title: string;
-    localDbId?: number;
-  } | null>(null);
-  const [handoffTarget, setHandoffTarget] = useState<{
-    id: string;
-    title: string;
-  } | null>(null);
+  // ── Effects ──────────────────────────────────────────────────────────────
+  useEffect(() => {
+    ensureActiveConversation();
+  }, [ensureActiveConversation]);
 
-  // Get projects for filtering - use useShallow to prevent re-renders from array reference changes
-  const projects = useProjectStore(useShallow(selectActiveProjects));
-  const activeProjectId = useProjectStore((state) => state.activeProjectId);
-
-  // Sync with active project from project store
   useEffect(() => {
     if (activeProjectId && !selectedProjectFilter) {
       setSelectedProjectFilter(activeProjectId);
     }
   }, [activeProjectId, selectedProjectFilter]);
 
-  // Get archived conversations - filter directly from conversations array
-  // to avoid dependency on store function which may cause re-render loops
-  const archivedConversations = useMemo(
-    () => conversations.filter((c) => c.archived === true),
-    [conversations],
-  );
-
-  // Run once on mount - ensureActiveConversation is a stable store function
-  useEffect(() => {
-    ensureActiveConversation();
-  }, [ensureActiveConversation]);
-
-  const filtered = useMemo(() => {
-    const term = searchQuery.trim().toLowerCase();
-    // Filter out archived conversations from main list (unless showing archived)
-    let baseList = showArchived
-      ? conversations.filter((c) => c.archived === true)
-      : conversations.filter((c) => !c.archived);
-
-    // Filter by project if selected
-    if (selectedProjectFilter) {
-      baseList = baseList.filter((c) => c.projectId === selectedProjectFilter);
-    }
-
-    if (!term) return baseList;
-    return baseList.filter((conv) => {
-      const haystack = `${conv.title ?? ''} ${conv.lastMessage ?? ''}`.toLowerCase();
-      return haystack.includes(term);
-    });
-  }, [conversations, searchQuery, showArchived, selectedProjectFilter]);
-
-  // Get selected project details
-  const selectedProject = useMemo(
-    () => (selectedProjectFilter ? projects.find((p) => p.id === selectedProjectFilter) : null),
-    [projects, selectedProjectFilter],
-  );
-
-  // Build a lookup map: projectId → project name, for O(1) attribution badge lookup
-  const projectNameById = useMemo<Map<string, string>>(() => {
-    const map = new Map<string, string>();
-    projects.forEach((p) => map.set(p.id, p.name));
-    return map;
-  }, [projects]);
-
-  const pinnedConversations = useMemo(
-    () =>
-      filtered
-        .filter((c) => c.pinned)
-        .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()),
-    [filtered],
-  );
-
-  const unpinnedConversations = useMemo(() => filtered.filter((c) => !c.pinned), [filtered]);
-
-  const groupedConversations = useMemo(() => {
-    const groups = new Map<TemporalGroup, ConversationSummary[]>();
-
-    unpinnedConversations.forEach((conv) => {
-      const group = getTemporalGroup(new Date(conv.updatedAt));
-      if (!groups.has(group)) {
-        groups.set(group, []);
-      }
-      groups.get(group)?.push(conv);
-    });
-
-    groups.forEach((convs) => {
-      convs.sort((a, b) => {
-        return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      });
-    });
-
-    return groups;
-  }, [unpinnedConversations]);
-
-  const visibleConversations = useMemo(() => {
-    const visible: ConversationSummary[] = [...pinnedConversations];
-    Array.from(groupedConversations.entries()).forEach(([group, convs]) => {
-      if (expandedGroups.has(group)) {
-        visible.push(...convs);
-      }
-    });
-    return visible;
-  }, [groupedConversations, expandedGroups, pinnedConversations]);
+  // ── Handlers ─────────────────────────────────────────────────────────────
 
   const handleNewChat = useCallback(async () => {
     if (onNewChat) {
@@ -643,53 +215,41 @@ export function Sidebar({
     }
   }, [createConversation, isIncognito, isMobile, onCollapsedChange, onNewChat, setActiveView]);
 
-  // Track the latest conversation selection to avoid race conditions when
-  // the user rapidly clicks different conversations.  Only the most recent
-  // selection should apply its loaded messages.
-  const latestSelectionRef = useRef<string | null>(null);
+  // Use a ref-style object so handleSelect doesn't close over a stale value
+  // while still being stable across renders.
+  const latestSelectedIdRef = useMemo(() => ({ current: null as string | null }), []);
 
-  const handleSelectConversation = useCallback(
+  const handleSelect = useCallback(
     (id: string) => {
-      // Mark this as the latest selection — any in-flight load for a
-      // previously-selected conversation will bail out via the stale check.
-      latestSelectionRef.current = id;
-
+      latestSelectedIdRef.current = id;
       selectConversationFn(id);
       setActiveView('chat');
       if (isMobile && onCollapsedChange) {
         onCollapsedChange(true);
       }
 
-      // Check if messages need to be loaded from the backend
-      // selectConversation sets isLoadingMessages=true when cache is empty
       const cachedMessages = messagesByConversation[id];
       if (!cachedMessages || cachedMessages.length === 0) {
-        // Get user ID for the API call
         const userId = cloudAccountAuth.getUser()?.id;
         if (userId) {
-          // Load messages from backend asynchronously
           loadConversationMessages(id, userId)
             .then(() => {
-              // If the user clicked a different conversation while this was
-              // loading, discard the result to prevent stale data overwriting
-              // the newer selection.
-              if (latestSelectionRef.current !== id) {
-                return; // stale — a newer selection superseded this one
-              }
+              // Discard result if user selected a different conversation while loading.
+              if (latestSelectedIdRef.current !== id) return;
             })
             .catch((error) => {
-              if (latestSelectionRef.current !== id) return; // stale
+              if (latestSelectedIdRef.current !== id) return;
               console.error('[Sidebar] Failed to load conversation messages:', error);
               toast.error('Failed to load conversation messages');
             });
         } else {
-          // BUG-342: Surface an error instead of silently skipping
           console.warn('[Sidebar] Cannot load messages: user not authenticated');
           toast.error('Please sign in to load conversation messages');
         }
       }
     },
     [
+      latestSelectedIdRef,
       selectConversationFn,
       setActiveView,
       isMobile,
@@ -700,38 +260,16 @@ export function Sidebar({
   );
 
   const handleRename = useCallback(
-    (id: string) => {
-      if (editingId !== id) return;
-      if (!editingTitle.trim()) {
-        setEditingId(null);
-        setEditingTitle('');
-        return;
-      }
-      renameConversation(id, editingTitle);
-      setEditingId(null);
-      setEditingTitle('');
+    (id: string, title: string) => {
+      if (!title.trim()) return;
+      renameConversation(id, title);
     },
-    [editingId, editingTitle, renameConversation],
+    [renameConversation],
   );
 
-  const startEditing = useCallback((conv: ConversationSummary) => {
-    setEditingId(conv.id);
-    setEditingTitle(conv.title);
-  }, []);
-
-  const toggleGroup = useCallback((group: TemporalGroup) => {
-    setExpandedGroups((prev) => {
-      const next = new Set(prev);
-      if (next.has(group)) {
-        next.delete(group);
-      } else {
-        next.add(group);
-      }
-      return next;
-    });
-  }, []);
-
-  const openDeleteConfirmDialog = useCallback((id: string, title: string) => {
+  const handleDelete = useCallback((id: string) => {
+    const conv = useChatStore.getState().conversations.find((c) => c.id === id);
+    const title = conv?.title || 'Untitled';
     setDeleteConfirmDialog({ open: true, conversationId: id, conversationTitle: title });
   }, []);
 
@@ -743,23 +281,12 @@ export function Sidebar({
     }
   }, [deleteConfirmDialog, deleteConversation]);
 
-  // Stable callback handlers for ConversationItem to prevent re-renders
-  const handleCancelEdit = useCallback(() => {
-    setEditingId(null);
-    setEditingTitle('');
-  }, []);
-
-  const handleShare = useCallback((id: string, title: string) => {
-    setShareDialog({ open: true, conversationId: id, conversationTitle: title });
-  }, []);
-
-  const handleTransfer = useCallback((id: string, title: string) => {
-    setTransferTarget({ id, title, localDbId: uuidToDbId(id) });
-  }, []);
-
-  const handleForkToByok = useCallback((id: string, title: string) => {
-    setHandoffTarget({ id, title });
-  }, []);
+  const handleTogglePin = useCallback(
+    (id: string) => {
+      togglePinnedConversation(id);
+    },
+    [togglePinnedConversation],
+  );
 
   const handleArchive = useCallback(
     (id: string) => {
@@ -777,180 +304,57 @@ export function Sidebar({
     [restoreConversation],
   );
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Guard: don't steal keystrokes from text inputs or editable elements
-      const target = e.target as HTMLElement;
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
-        return;
-      }
+  const handleShare = useCallback((id: string) => {
+    const conv = useChatStore.getState().conversations.find((c) => c.id === id);
+    const title = conv?.title || 'Untitled';
+    setShareDialog({ open: true, conversationId: id, conversationTitle: title });
+  }, []);
 
-      // Handle Escape - close search and reset state
-      if (e.key === 'Escape') {
-        setShowSearch(false);
-        setSearchQuery('');
-        setFocusedIndex(-1);
-        return;
-      }
+  const handleOpenProjects = useCallback(() => {
+    setActiveView('projects');
+  }, [setActiveView]);
 
-      // Skip arrow navigation if editing or in search mode
-      if (editingId || showSearch) return;
+  const handleOpenSkills = useCallback(() => {
+    setActiveView('skills');
+  }, [setActiveView]);
 
-      // Handle arrow navigation
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        setFocusedIndex((prev) => {
-          const next = prev + 1;
-          return next >= visibleConversations.length ? 0 : next;
-        });
-      } else if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        setFocusedIndex((prev) => {
-          const next = prev - 1;
-          return next < 0 ? visibleConversations.length - 1 : next;
-        });
-      } else if (e.key === 'Enter' && focusedIndex >= 0) {
-        e.preventDefault();
-        const conversation = visibleConversations[focusedIndex];
-        if (conversation) {
-          handleSelectConversation(conversation.id);
-          setFocusedIndex(-1);
-        }
-      }
-    };
+  const handleModeClick = useCallback(() => {
+    if (mode === 'local') {
+      void openExternalUrl('https://agiworkforce.com/waitlist');
+    } else {
+      setMode('local');
+    }
+  }, [mode, setMode]);
 
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [editingId, showSearch, focusedIndex, visibleConversations, handleSelectConversation]);
+  const handleOpenUsage = useCallback(() => {
+    openSettings('account');
+  }, [openSettings]);
 
-  // Render conversation item using the memoized component
-  const renderConversationItem = useCallback(
-    (conv: ConversationSummary, isKeyboardFocused: boolean) => (
-      <ConversationItem
-        key={conv.id}
-        conv={conv}
-        isActive={conv.id === activeConversationId}
-        isKeyboardFocused={isKeyboardFocused}
-        isSimpleMode={isSimpleMode}
-        showArchived={showArchived}
-        editingId={editingId}
-        editingTitle={editingTitle}
-        projectName={conv.projectId ? projectNameById.get(conv.projectId) : undefined}
-        onSelect={handleSelectConversation}
-        onStartEdit={startEditing}
-        onEditTitleChange={setEditingTitle}
-        onRename={handleRename}
-        onCancelEdit={handleCancelEdit}
-        onOpenCustomInstructions={onOpenCustomInstructions}
-        onTogglePin={togglePinnedConversation}
-        onShare={handleShare}
-        onTransfer={handleTransfer}
-        onForkToByok={handleForkToByok}
-        onExport={handleExportConversation}
-        onExportPdf={handleExportPdf}
-        onArchive={handleArchive}
-        onRestore={handleRestore}
-        onDelete={openDeleteConfirmDialog}
-      />
-    ),
-    [
-      activeConversationId,
-      isSimpleMode,
-      showArchived,
-      editingId,
-      editingTitle,
-      projectNameById,
-      handleSelectConversation,
-      startEditing,
-      handleRename,
-      handleCancelEdit,
-      onOpenCustomInstructions,
-      togglePinnedConversation,
-      handleShare,
-      handleTransfer,
-      handleForkToByok,
-      handleExportConversation,
-      handleExportPdf,
-      handleArchive,
-      handleRestore,
-      openDeleteConfirmDialog,
-    ],
+  // ── Data mapping ─────────────────────────────────────────────────────────
+  const sessions = useMemo<SidebarSession[]>(
+    () => conversations.map(toSidebarSession),
+    [conversations],
   );
 
-  if (collapsed) {
-    return (
-      <div className="w-16 flex flex-col bg-[hsl(var(--card))] border-r border-[hsl(var(--border))] transition-all duration-300 ease-in-out">
-        <div className="p-3 flex flex-col items-center gap-4">
-          <Button
-            onClick={onToggleCollapse}
-            variant="ghost"
-            size="icon"
-            aria-label="Expand sidebar"
-            className="text-[hsl(var(--muted-foreground))]"
-          >
-            <PanelLeft className="h-4 w-4" />
-          </Button>
-          <Button
-            onClick={handleNewChat}
-            variant="ghost"
-            size="icon"
-            aria-label="New chat"
-            className="text-[hsl(var(--muted-foreground))]"
-          >
-            <Plus className="h-4 w-4" />
-          </Button>
-          <Button
-            onClick={() => {
-              if (onToggleCollapse) onToggleCollapse();
-              setShowSearch(true);
-            }}
-            variant="ghost"
-            size="icon"
-            aria-label="Search conversations"
-            className="text-[hsl(var(--muted-foreground))]"
-          >
-            <Search className="h-4 w-4" />
-          </Button>
-          <Button
-            onClick={() => {
-              if (onToggleCollapse) onToggleCollapse();
-              setActiveView('projects');
-            }}
-            variant="ghost"
-            size="icon"
-            aria-label="Projects"
-            className="text-[hsl(var(--muted-foreground))]"
-          >
-            <FolderOpen className="h-4 w-4" />
-          </Button>
-          <Button
-            onClick={() => {
-              if (onToggleCollapse) onToggleCollapse();
-              setActiveView('skills');
-            }}
-            variant="ghost"
-            size="icon"
-            aria-label="Skills"
-            className="text-[hsl(var(--muted-foreground))]"
-          >
-            <Sparkles className="h-4 w-4" />
-          </Button>
-          {/* Mode dot — collapsed state shows only the colored dot */}
-          <div
-            title={
-              mode === 'local'
-                ? formatChatExecutionModeLabel('local_only')
-                : formatChatExecutionModeLabel('cloud_managed')
-            }
-            className={cn(
-              'w-2 h-2 rounded-full',
-              mode === 'local' ? 'bg-emerald-400' : 'bg-blue-400',
-            )}
-          />
-        </div>
+  const sidebarProjects = useMemo<SidebarProject[]>(
+    () => projects.map(toSidebarProject),
+    [projects],
+  );
+
+  // ── Footer slot (desktop-only chrome) ────────────────────────────────────
+  const footerSlot = (
+    <div className="flex items-center gap-1.5 overflow-hidden w-full">
+      {!collapsed && <SimpleModeToggle compact />}
+      <div className="flex-1 min-w-0 overflow-hidden">
+        <UserProfile collapsed={collapsed} />
       </div>
-    );
-  }
+    </div>
+  );
+
+  // ── Header slot (incognito toggle) ────────────────────────────────────────
+  const headerSlot = (
+    <IncognitoToggle isIncognito={isIncognito} onToggle={() => setIsIncognito((prev) => !prev)} />
+  );
 
   return (
     <>
@@ -987,103 +391,9 @@ export function Sidebar({
         onClose={() => setShareDialog((prev) => ({ ...prev, open: false }))}
       />
 
-      {/* Transfer Conversation Dialog */}
-      {transferTarget && (
-        <TransferDialog
-          conversationId={transferTarget.id}
-          conversationTitle={transferTarget.title}
-          direction={mode === 'local' ? 'local_to_cloud' : 'cloud_to_local'}
-          localDbId={transferTarget.localDbId}
-          onClose={() => setTransferTarget(null)}
-        />
-      )}
-      {handoffTarget && (
-        <LocalByokHandoffDialog
-          conversationId={handoffTarget.id}
-          conversationTitle={handoffTarget.title}
-          onClose={() => setHandoffTarget(null)}
-        />
-      )}
-
-      {}
-      <AnimatePresence>
-        {showSearch && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="fixed inset-0 z-50 bg-black/50 backdrop-blur-xs"
-            onClick={() => setShowSearch(false)}
-          >
-            <motion.div
-              initial={{ scale: 0.95, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.95, opacity: 0 }}
-              className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-2xl"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <div className="bg-[hsl(var(--card))] rounded-xl shadow-2xl overflow-hidden">
-                <div className="flex items-center gap-3 px-5 py-4 border-b border-[hsl(var(--border))]">
-                  <Search className="h-5 w-5 text-[hsl(var(--muted-foreground))]" />
-                  <Input
-                    autoFocus
-                    placeholder="Search conversations..."
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    className="flex-1 border-0 bg-transparent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden"
-                  />
-                  <kbd className="px-2 py-1 text-xs bg-[hsl(var(--muted))] text-[hsl(var(--muted-foreground))] rounded">
-                    ESC
-                  </kbd>
-                </div>
-                <ScrollArea className="max-h-96">
-                  <div className="p-2">
-                    {filtered.slice(0, 10).map((conv) => (
-                      <button
-                        type="button"
-                        key={conv.id}
-                        onClick={() => {
-                          selectConversationFn(conv.id);
-                          setActiveView('chat');
-                          setShowSearch(false);
-                          setSearchQuery('');
-                        }}
-                        className={cn(
-                          'w-full text-left px-3 py-2 rounded-lg transition-colors',
-                          conv.id === activeConversationId
-                            ? 'bg-primary/10'
-                            : 'hover:bg-[hsl(var(--accent))]',
-                        )}
-                      >
-                        <div className="font-medium text-sm">{conv.title}</div>
-                        {conv.lastMessage && (
-                          <div className="text-xs text-[hsl(var(--muted-foreground))] truncate mt-1">
-                            {conv.lastMessage}
-                          </div>
-                        )}
-                      </button>
-                    ))}
-                  </div>
-                </ScrollArea>
-              </div>
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-
-      <div
-        className={cn(
-          'flex flex-col bg-[hsl(var(--card))] border-r border-[hsl(var(--border))] transition-all duration-300 ease-in-out relative',
-          isIncognito && 'border-purple-500/30',
-          className,
-        )}
-        style={{ width: width }}
-      >
-        {/* Incognito mode subtle top stripe */}
-        {isIncognito && (
-          <div className="absolute inset-x-0 top-0 h-0.5 bg-gradient-to-r from-transparent via-purple-500/60 to-transparent pointer-events-none z-10" />
-        )}
-        {onResize && !collapsed && (
+      {/* Resize handle — rendered outside SharedSidebar so it can overlap the border */}
+      {onResize && !collapsed && (
+        <div className="relative" style={{ width: 0, height: '100%' }}>
           <ResizeHandle
             width={width}
             onResize={onResize}
@@ -1091,334 +401,45 @@ export function Sidebar({
             minWidth={200}
             maxWidth={400}
           />
-        )}
-        {}
-        <div className="p-4 border-b border-[hsl(var(--border))]">
-          <div className="flex items-center justify-between mb-3">
-            <Button
-              onClick={onToggleCollapse}
-              variant="ghost"
-              size="icon"
-              className="text-[hsl(var(--muted-foreground))]"
-            >
-              <PanelLeft className="h-4 w-4" />
-            </Button>
-            <div className="flex items-center gap-1.5">
-              <IncognitoToggle
-                isIncognito={isIncognito}
-                onToggle={() => setIsIncognito((prev) => !prev)}
-              />
-              <Button
-                onClick={handleNewChat}
-                className={cn(
-                  'flex items-center gap-2 transition-colors',
-                  isIncognito
-                    ? 'bg-purple-500/15 hover:bg-purple-500/25 text-purple-600 dark:text-purple-400 ring-1 ring-purple-500/30'
-                    : 'bg-[hsl(var(--muted))] hover:bg-[hsl(var(--accent))] text-[hsl(var(--foreground))]',
-                )}
-              >
-                <Plus className="h-4 w-4" />
-                New Chat
-              </Button>
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={() => setShowSearch(true)}
-            className="w-full flex items-center gap-2 px-3 py-2 bg-[hsl(var(--muted))] rounded-lg text-sm text-[hsl(var(--foreground))] hover:bg-[hsl(var(--accent))] transition-colors"
-          >
-            <Search className="h-4 w-4" />
-            <span>Search</span>
-            <div className="ml-auto flex items-center gap-1">
-              <kbd className="px-1.5 py-0.5 text-xs bg-[hsl(var(--card))] rounded">
-                {modKeySymbol}
-              </kbd>
-              <kbd className="px-1.5 py-0.5 text-xs bg-[hsl(var(--card))] rounded">K</kbd>
-            </div>
-          </button>
         </div>
+      )}
 
-        {/* Minimal navigation */}
-        {!collapsed && !isSimpleMode && (
-          <div className="px-2 py-1.5 border-b border-[hsl(var(--border))] space-y-0.5">
-            {[
-              {
-                id: 'projects',
-                label: 'Projects',
-                icon: FolderOpen,
-                onClick: () => setActiveView('projects'),
-                isActive: activeView === 'projects',
-              },
-              {
-                id: 'skills',
-                label: 'Skills',
-                icon: Sparkles,
-                onClick: () => setActiveView('skills'),
-                isActive: activeView === 'skills',
-              },
-            ].map(({ id, label, icon: Icon, onClick, isActive }) => (
-              <button
-                key={id}
-                type="button"
-                onClick={onClick}
-                className={cn(
-                  'w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm font-medium transition-colors',
-                  'focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden',
-                  isActive
-                    ? 'bg-white/10 text-[hsl(var(--foreground))]'
-                    : 'text-[hsl(var(--muted-foreground))] hover:bg-white/5 hover:text-[hsl(var(--foreground))]',
-                )}
-              >
-                <Icon className="h-4 w-4 shrink-0" />
-                <span>{label}</span>
-              </button>
-            ))}
-          </div>
-        )}
-
-        {/* Compact filter bar: project filter + archive toggle */}
-        {!collapsed && !isSimpleMode && (
-          <div className="px-3 py-2 flex items-center gap-1">
-            {/* Project filter dropdown */}
-            {projects.length > 0 && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <button
-                    type="button"
-                    className={cn(
-                      'flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-lg transition-colors',
-                      selectedProjectFilter
-                        ? 'bg-blue-500/10 text-blue-600 dark:text-blue-400'
-                        : 'text-muted-foreground hover:bg-surface-hover',
-                    )}
-                  >
-                    <span
-                      className={cn(
-                        'w-4 h-4 flex items-center justify-center rounded',
-                        selectedProjectFilter
-                          ? 'text-blue-500'
-                          : 'bg-[hsl(var(--muted))] text-[hsl(var(--muted-foreground))]',
-                      )}
-                      style={
-                        selectedProject?.color
-                          ? {
-                              backgroundColor: `${selectedProject.color}20`,
-                              color: selectedProject.color,
-                            }
-                          : undefined
-                      }
-                    >
-                      <FolderOpen className="w-3 h-3" />
-                    </span>
-                    <span className="truncate max-w-[100px]">{selectedProject?.name || 'All'}</span>
-                    <ChevronDown className="w-3 h-3 text-[hsl(var(--muted-foreground))]" />
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  align="start"
-                  className="w-56 bg-[hsl(var(--popover))] border-[hsl(var(--border))]"
-                >
-                  <DropdownMenuItem
-                    onClick={() => setSelectedProjectFilter(null)}
-                    className={cn(
-                      'text-[hsl(var(--popover-foreground))]',
-                      !selectedProjectFilter && 'bg-[hsl(var(--accent))]',
-                    )}
-                  >
-                    <MessageSquare className="w-4 h-4 mr-2" />
-                    All Conversations
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator className="bg-[hsl(var(--border))]" />
-                  {projects.map((project) => (
-                    <DropdownMenuItem
-                      key={project.id}
-                      onClick={() => setSelectedProjectFilter(project.id)}
-                      className={cn(
-                        'text-[hsl(var(--popover-foreground))]',
-                        selectedProjectFilter === project.id && 'bg-[hsl(var(--accent))]',
-                      )}
-                    >
-                      <span
-                        className="w-4 h-4 rounded mr-2 flex items-center justify-center"
-                        style={{ backgroundColor: project.color || '#3b82f6' }}
-                      >
-                        <Layers className="w-2.5 h-2.5 text-white" />
-                      </span>
-                      <span className="truncate">{project.name}</span>
-                      <span className="ml-auto text-xs text-[hsl(var(--muted-foreground))]">
-                        {conversations.filter((c) => c.projectId === project.id).length}
-                      </span>
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
-
-            {/* Clear project filter */}
-            {selectedProjectFilter && (
-              <Button
-                onClick={() => setSelectedProjectFilter(null)}
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 text-[hsl(var(--muted-foreground))] hover:text-[hsl(var(--foreground))]"
-                title="Clear filter"
-              >
-                <X className="w-3 h-3" />
-              </Button>
-            )}
-
-            {/* Spacer */}
-            <div className="flex-1" />
-
-            {/* Archive toggle (icon button) */}
-            {archivedConversations.length > 0 && (
-              <Button
-                onClick={() => setShowArchived(!showArchived)}
-                variant="ghost"
-                size="icon"
-                className={cn(
-                  'h-7 w-7',
-                  showArchived
-                    ? 'text-amber-600 dark:text-amber-400'
-                    : 'text-[hsl(var(--muted-foreground))]',
-                )}
-                title={showArchived ? 'Show active' : `Archived (${archivedConversations.length})`}
-              >
-                <Archive className="w-3.5 h-3.5" />
-              </Button>
-            )}
-          </div>
-        )}
-
-        {}
-        <ScrollArea className="flex-1">
-          <div className="p-2">
-            {}
-            {pinnedConversations.length > 0 && (
-              <div className="mb-6">
-                <div className="px-3 mb-2 text-xs font-semibold text-[hsl(var(--muted-foreground))] uppercase tracking-wider flex items-center gap-1">
-                  <Pin className="w-3 h-3" /> Pinned
-                </div>
-                {pinnedConversations.map((conv) => {
-                  const globalIndex = visibleConversations.findIndex((c) => c.id === conv.id);
-                  return renderConversationItem(conv, globalIndex === focusedIndex);
-                })}
-              </div>
-            )}
-
-            {}
-            {Array.from(groupedConversations.entries()).map(([group, convs]) => (
-              <div key={group} className="mb-4">
-                <button
-                  type="button"
-                  onClick={() => toggleGroup(group)}
-                  aria-expanded={expandedGroups.has(group)}
-                  aria-controls={`conversation-group-${group}`}
-                  className="w-full flex items-center gap-2 px-2 py-1 text-xs font-medium text-[hsl(var(--muted-foreground))] hover:text-[hsl(var(--foreground))] transition-colors"
-                >
-                  <ChevronRight
-                    className={cn(
-                      'h-3 w-3 transition-transform',
-                      expandedGroups.has(group) && 'rotate-90',
-                    )}
-                  />
-                  <span className="flex items-center gap-1">
-                    {group === 'today' && <Calendar className="h-3 w-3" />}
-                    {group === 'yesterday' && <Clock className="h-3 w-3" />}
-                    {TEMPORAL_LABELS[group]}
-                  </span>
-                  <span className="ml-auto text-[hsl(var(--muted-foreground))]">
-                    ({convs.length})
-                  </span>
-                </button>
-
-                <AnimatePresence>
-                  {expandedGroups.has(group) && (
-                    <motion.div
-                      id={`conversation-group-${group}`}
-                      initial={{ height: 0, opacity: 0 }}
-                      animate={{ height: 'auto', opacity: 1 }}
-                      exit={{ height: 0, opacity: 0 }}
-                      transition={{ duration: 0.2 }}
-                      className="mt-1 space-y-1"
-                    >
-                      {convs.map((conv) => {
-                        const globalIndex = visibleConversations.findIndex((c) => c.id === conv.id);
-                        return renderConversationItem(conv, globalIndex === focusedIndex);
-                      })}
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </div>
-            ))}
-          </div>
-        </ScrollArea>
-
-        {/* Bottom bar: usage widget (when > 50%) + SimpleModeToggle + UserProfile + NotificationCenter */}
-        <div className="mt-auto border-t border-[hsl(var(--border))] px-3 py-2.5 space-y-2">
-          {/* Sidebar usage widget — only visible when budget is enabled and > 50% used */}
-          {!collapsed && showUsageWidget && (
-            <button
-              type="button"
-              onClick={() => openSettings('account')}
-              title={`${Math.round(clampedBudgetPct)}% of token budget used — click to manage`}
-              className="w-full group flex items-center gap-2 px-1 py-1 rounded-md hover:bg-white/5 transition-colors"
-            >
-              <div className="flex-1 h-1 rounded-full bg-white/10 overflow-hidden">
-                <div
-                  className={cn(
-                    'h-full rounded-full transition-all duration-300',
-                    clampedBudgetPct >= 95
-                      ? 'bg-red-500'
-                      : clampedBudgetPct >= 80
-                        ? 'bg-amber-500'
-                        : 'bg-blue-500',
-                  )}
-                  style={{ width: `${clampedBudgetPct}%` }}
-                />
-              </div>
-              <span className="text-[10px] tabular-nums text-muted-foreground group-hover:text-foreground transition-colors shrink-0">
-                {Math.round(clampedBudgetPct)}%
-              </span>
-            </button>
-          )}
-          <div className="flex items-center gap-1.5 overflow-hidden">
-            {!collapsed && <SimpleModeToggle compact />}
-            <div className="flex-1 min-w-0 overflow-hidden">
-              <UserProfile collapsed={collapsed} />
-            </div>
-            {/* Mode toggle pill — expanded state (hidden in web mode, always cloud) */}
-            {!collapsed && isTauri && (
-              <button
-                type="button"
-                onClick={() => {
-                  if (mode === 'local') {
-                    void openExternalUrl('https://agiworkforce.com/waitlist');
-                    return;
-                  }
-                  setMode('local');
-                }}
-                title={
-                  mode === 'local'
-                    ? 'Join Cloud Managed waitlist'
-                    : `Switch to ${formatChatExecutionModeLabel('local_only')}`
-                }
-                className={cn(
-                  'px-2 py-0.5 rounded-full text-[10px] font-medium uppercase tracking-wider shrink-0 transition-colors cursor-pointer',
-                  mode === 'local'
-                    ? 'bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30'
-                    : 'bg-blue-500/20 text-blue-400 hover:bg-blue-500/30',
-                )}
-              >
-                {mode === 'local'
-                  ? formatChatExecutionModeLabel('local_only')
-                  : formatChatExecutionModeLabel('cloud_managed')}
-              </button>
-            )}
-            {!collapsed && <NotificationCenter className="shrink-0" />}
-          </div>
-        </div>
-      </div>
+      {/* The shared pure-presentation sidebar */}
+      <SharedSidebar
+        className={cn(isIncognito && 'border-purple-500/30', className)}
+        sessions={sessions}
+        activeSessionId={activeConversationId ?? undefined}
+        projects={sidebarProjects}
+        selectedProjectFilter={selectedProjectFilter}
+        collapsed={collapsed}
+        width={width}
+        isMobile={isMobile}
+        isSimpleMode={isSimpleMode}
+        mode={mode === 'local' ? 'local' : 'cloud'}
+        budgetPercent={clampedBudgetPct}
+        showUsageWidget={showUsageWidget}
+        // handlers
+        onNewChat={handleNewChat}
+        onToggleCollapse={onToggleCollapse}
+        onSelectProjectFilter={setSelectedProjectFilter}
+        onOpenProjects={handleOpenProjects}
+        onOpenSkills={handleOpenSkills}
+        onModeClick={isTauri ? handleModeClick : undefined}
+        onOpenUsage={handleOpenUsage}
+        // per-session handlers
+        onSelect={handleSelect}
+        onRename={handleRename}
+        onDelete={handleDelete}
+        onTogglePin={handleTogglePin}
+        onArchive={handleArchive}
+        onRestore={handleRestore}
+        onShare={handleShare}
+        onOpenCustomInstructions={onOpenCustomInstructions}
+        // slots
+        headerSlot={headerSlot}
+        footerSlot={footerSlot}
+        navItems={isSimpleMode ? [] : undefined}
+      />
     </>
   );
 }

--- a/apps/desktop/src/runtime/TauriRuntime.ts
+++ b/apps/desktop/src/runtime/TauriRuntime.ts
@@ -439,6 +439,7 @@ export class TauriRuntime implements ChatRuntime {
 
     // Kick off the Rust-side stream after listeners are ready.
     try {
+      const activeMode = useAppModeStore.getState().mode;
       await invoke('chat_send_message', {
         request: {
           content,
@@ -449,7 +450,10 @@ export class TauriRuntime implements ChatRuntime {
           attachments: attachments ?? [],
           stream: true,
           frontendMessageId,
-          preferCloudCredits: useAppModeStore.getState().mode === 'cloud',
+          // activeMode is the authoritative trust-boundary signal.  The backend
+          // MUST honor this: "local" => no ManagedCloud, "cloud" => cloud only.
+          activeMode,
+          preferCloudCredits: activeMode === 'cloud',
           // Composer controls — the Rust ChatSendMessageRequest already accepts
           // these camelCase aliases; they were previously dropped client-side.
           thinkingMode: thinkingEnabled,
@@ -506,8 +510,12 @@ export class TauriRuntime implements ChatRuntime {
   }
 
   async loadConversations(): Promise<Conversation[]> {
+    // Pass the active mode so the backend applies strict mode-scoped filtering:
+    // Local conversations never appear in Cloud mode and vice-versa.
+    const appMode = useAppModeStore.getState().mode;
     const raw = await invoke<RawConversation[]>('chat_get_conversations', {
       userId: this.getCurrentUserId(),
+      appMode,
     });
     return Array.isArray(raw) ? raw.map(mapConversation) : [];
   }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -22,7 +22,12 @@ const DEFAULT_DEV_PORT = 5173;
 export default defineConfig(async ({ mode }: ConfigEnv) => {
   // Load environment variables based on mode (development, production, test)
   const env = loadEnv(mode, process.cwd(), ['VITE_', 'TAURI_']);
-  const isWebBuild = env['VITE_BUILD_TARGET'] === 'web';
+  // loadEnv only reads .env files; honor a VITE_BUILD_TARGET passed as a process
+  // env var too (CI sets it as a step env; `build:cloud` sets it inline). Without
+  // this, `build:web` falls through to the native safari14 target and esbuild
+  // fails lowering destructuring (368 errors).
+  const isWebBuild =
+    env['VITE_BUILD_TARGET'] === 'web' || process.env['VITE_BUILD_TARGET'] === 'web';
 
   // Determine port configuration
   const requestedPort = Number(env['VITE_DEV_PORT']) || DEFAULT_DEV_PORT;

--- a/apps/extension/__tests__/autofill-escalation-agent-integration.test.ts
+++ b/apps/extension/__tests__/autofill-escalation-agent-integration.test.ts
@@ -467,7 +467,7 @@ describe('AGI_START_COMPUTER_USE background handler → runAgentLoop', () => {
     // Gateway was called twice (once for tool_call, once for final)
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const firstCall = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(firstCall[0]).toBe('https://api.agiworkforce.com/v1/chat/completions');
+    expect(firstCall[0]).toBe('https://api.agiworkforce.com/api/llm/v1/chat/completions');
     const firstBody = JSON.parse(firstCall[1].body as string) as {
       messages: Array<{ role: string; content: unknown }>;
       stream: boolean;

--- a/apps/extension/__tests__/computer-use-agent-loop.test.ts
+++ b/apps/extension/__tests__/computer-use-agent-loop.test.ts
@@ -275,7 +275,7 @@ describe('computer-use agent loop — one round-trip', () => {
 
     // ── First call: correct endpoint + model + tools ────────────────────────
     const firstCallArgs = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(firstCallArgs[0]).toBe('https://api.agiworkforce.com/v1/chat/completions');
+    expect(firstCallArgs[0]).toBe('https://api.agiworkforce.com/api/llm/v1/chat/completions');
     const firstBody = JSON.parse(firstCallArgs[1].body as string) as {
       model: string;
       tools: Array<{ function: { name: string } }>;

--- a/apps/extension/__tests__/free-trial-quota.test.ts
+++ b/apps/extension/__tests__/free-trial-quota.test.ts
@@ -1,0 +1,633 @@
+/**
+ * Tests for apps/extension/src/features/cloud-bridge/freeTrialClient.ts
+ *
+ * Covers:
+ *   - Constants: FREE_TRIAL_PROMPT_LIMIT, FREE_TRIAL_MODEL, FREE_TRIAL_ENDPOINT
+ *   - Auth: getAuthToken (session → local fallback → null), storeSessionToken, clearAuthToken
+ *   - Quota helpers: getFreePromptsUsed, getRemainingFreePrompts
+ *   - streamFreeChat: happy-path SSE streaming, quota_exceeded (403), auth_required (401),
+ *     server_error (5xx), network failure, abort, input truncation, [DONE] sentinel,
+ *     inline stream error, post-stream done without [DONE]
+ *
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Chrome storage shim — hoisted before module imports
+// ---------------------------------------------------------------------------
+
+const chromeMock = vi.hoisted(() => {
+  const localStore: Record<string, unknown> = {};
+  const sessionStore: Record<string, unknown> = {};
+
+  const mock = {
+    storage: {
+      local: {
+        get: vi.fn(async (keys: string | string[]): Promise<Record<string, unknown>> => {
+          const result: Record<string, unknown> = {};
+          const keyList = Array.isArray(keys) ? keys : [keys];
+          for (const k of keyList) {
+            if (k in localStore) result[k] = localStore[k];
+          }
+          return result;
+        }),
+        set: vi.fn(async (items: Record<string, unknown>): Promise<void> => {
+          Object.assign(localStore, items);
+        }),
+        remove: vi.fn(async (keys: string[]): Promise<void> => {
+          for (const k of keys) delete localStore[k];
+        }),
+      },
+      session: {
+        get: vi.fn(async (keys: string[]): Promise<Record<string, unknown>> => {
+          const result: Record<string, unknown> = {};
+          for (const k of keys) {
+            if (k in sessionStore) result[k] = sessionStore[k];
+          }
+          return result;
+        }),
+        set: vi.fn(async (items: Record<string, unknown>): Promise<void> => {
+          Object.assign(sessionStore, items);
+        }),
+        remove: vi.fn(async (keys: string[]): Promise<void> => {
+          for (const k of keys) delete sessionStore[k];
+        }),
+      },
+    },
+    _localStore: localStore,
+    _sessionStore: sessionStore,
+  };
+
+  (globalThis as Record<string, unknown>).chrome = mock;
+  return mock;
+});
+
+// ---------------------------------------------------------------------------
+// fetch stub — hoisted
+// ---------------------------------------------------------------------------
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+// ---------------------------------------------------------------------------
+// Imports — after mock hoisting
+// ---------------------------------------------------------------------------
+
+import {
+  FREE_TRIAL_PROMPT_LIMIT,
+  FREE_TRIAL_MODEL,
+  FREE_TRIAL_ENDPOINT,
+  FREE_PROMPTS_USED_KEY,
+  getAuthToken,
+  storeSessionToken,
+  clearAuthToken,
+  getFreePromptsUsed,
+  getRemainingFreePrompts,
+  streamFreeChat,
+  type FreeTrialMessage,
+  type FreeTrialChunk,
+} from '../src/features/cloud-bridge/freeTrialClient';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Collect all chunks from the async generator. */
+async function collectChunks(gen: AsyncGenerator<FreeTrialChunk>): Promise<FreeTrialChunk[]> {
+  const chunks: FreeTrialChunk[] = [];
+  for await (const chunk of gen) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+/** Build a fake SSE ReadableStream from a list of data payloads. */
+function makeSseStream(dataLines: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const lines = dataLines.map((d) => `data: ${d}\n\n`).join('');
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(lines));
+      controller.close();
+    },
+  });
+}
+
+/** Construct a fake Response with a body stream. */
+function makeStreamResponse(dataLines: string[], status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    body: makeSseStream(dataLines),
+    text: vi.fn().mockResolvedValue(''),
+  } as unknown as Response;
+}
+
+/** Construct a fake error Response (no body stream). */
+function makeErrorResponse(status: number, bodyText: string): Response {
+  return {
+    ok: false,
+    status,
+    body: null,
+    text: vi.fn().mockResolvedValue(bodyText),
+  } as unknown as Response;
+}
+
+const SAMPLE_MESSAGES: FreeTrialMessage[] = [{ role: 'user', content: 'Hello!' }];
+
+// ---------------------------------------------------------------------------
+// Reset between tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  // Clear all storage
+  for (const k of Object.keys(chromeMock._localStore)) delete chromeMock._localStore[k];
+  for (const k of Object.keys(chromeMock._sessionStore)) delete chromeMock._sessionStore[k];
+  vi.clearAllMocks();
+  // Re-install chrome global after clearAllMocks resets mocks
+  (globalThis as Record<string, unknown>).chrome = chromeMock;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe('constants', () => {
+  it('FREE_TRIAL_PROMPT_LIMIT is 3', () => {
+    expect(FREE_TRIAL_PROMPT_LIMIT).toBe(3);
+  });
+
+  it('FREE_TRIAL_MODEL is a non-empty string read from models.json', () => {
+    expect(typeof FREE_TRIAL_MODEL).toBe('string');
+    expect(FREE_TRIAL_MODEL.length).toBeGreaterThan(0);
+    // Must not be a hardcoded sentinel — should contain known economy model name fragments
+    // (gemini, gpt-mini, flash, etc.)
+    expect(FREE_TRIAL_MODEL).toMatch(/flash|mini|lite|haiku|turbo|economy/i);
+  });
+
+  it('FREE_TRIAL_ENDPOINT points at agiworkforce.com web app (not api.agiworkforce.com)', () => {
+    expect(FREE_TRIAL_ENDPOINT).toContain('agiworkforce.com/api/llm/v1/chat/completions');
+    expect(FREE_TRIAL_ENDPOINT).not.toContain('api.agiworkforce.com');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth: getAuthToken
+// ---------------------------------------------------------------------------
+
+describe('getAuthToken', () => {
+  it('returns null when both stores are empty', async () => {
+    expect(await getAuthToken()).toBeNull();
+  });
+
+  it('returns session token when agi_clerk_session_token is set', async () => {
+    chromeMock._sessionStore['agi_clerk_session_token'] = 'sess-token-abc';
+    expect(await getAuthToken()).toBe('sess-token-abc');
+  });
+
+  it('falls back to local dev token when session is empty', async () => {
+    chromeMock._localStore['agi_dev_bearer_token'] = 'dev-token-xyz';
+    expect(await getAuthToken()).toBe('dev-token-xyz');
+  });
+
+  it('prefers session token over local dev token', async () => {
+    chromeMock._sessionStore['agi_clerk_session_token'] = 'sess-token';
+    chromeMock._localStore['agi_dev_bearer_token'] = 'dev-token';
+    expect(await getAuthToken()).toBe('sess-token');
+  });
+
+  it('ignores empty string tokens', async () => {
+    chromeMock._sessionStore['agi_clerk_session_token'] = '';
+    chromeMock._localStore['agi_dev_bearer_token'] = '';
+    expect(await getAuthToken()).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth: storeSessionToken
+// ---------------------------------------------------------------------------
+
+describe('storeSessionToken', () => {
+  it('writes to session storage when available', async () => {
+    await storeSessionToken('my-token');
+    expect(chromeMock._sessionStore['agi_clerk_session_token']).toBe('my-token');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth: clearAuthToken
+// ---------------------------------------------------------------------------
+
+describe('clearAuthToken', () => {
+  it('removes both session and local tokens', async () => {
+    chromeMock._sessionStore['agi_clerk_session_token'] = 'sess';
+    chromeMock._localStore['agi_dev_bearer_token'] = 'dev';
+    await clearAuthToken();
+    expect(chromeMock._sessionStore['agi_clerk_session_token']).toBeUndefined();
+    expect(chromeMock._localStore['agi_dev_bearer_token']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Quota: getFreePromptsUsed / getRemainingFreePrompts
+// ---------------------------------------------------------------------------
+
+describe('getFreePromptsUsed', () => {
+  it('returns 0 when counter is unset', async () => {
+    expect(await getFreePromptsUsed()).toBe(0);
+  });
+
+  it('returns the stored count', async () => {
+    chromeMock._localStore[FREE_PROMPTS_USED_KEY] = 2;
+    expect(await getFreePromptsUsed()).toBe(2);
+  });
+
+  it('clamps stored value to FREE_TRIAL_PROMPT_LIMIT', async () => {
+    chromeMock._localStore[FREE_PROMPTS_USED_KEY] = 99;
+    expect(await getFreePromptsUsed()).toBe(FREE_TRIAL_PROMPT_LIMIT);
+  });
+
+  it('ignores non-numeric stored values and returns 0', async () => {
+    chromeMock._localStore[FREE_PROMPTS_USED_KEY] = 'bad';
+    expect(await getFreePromptsUsed()).toBe(0);
+  });
+});
+
+describe('getRemainingFreePrompts', () => {
+  it('returns FREE_TRIAL_PROMPT_LIMIT when no prompts used', async () => {
+    expect(await getRemainingFreePrompts()).toBe(FREE_TRIAL_PROMPT_LIMIT);
+  });
+
+  it('returns correct remaining count', async () => {
+    chromeMock._localStore[FREE_PROMPTS_USED_KEY] = 1;
+    expect(await getRemainingFreePrompts()).toBe(2);
+  });
+
+  it('returns 0 when limit reached', async () => {
+    chromeMock._localStore[FREE_PROMPTS_USED_KEY] = FREE_TRIAL_PROMPT_LIMIT;
+    expect(await getRemainingFreePrompts()).toBe(0);
+  });
+
+  it('never returns negative remaining count', async () => {
+    chromeMock._localStore[FREE_PROMPTS_USED_KEY] = FREE_TRIAL_PROMPT_LIMIT + 5;
+    expect(await getRemainingFreePrompts()).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamFreeChat — network failure
+// ---------------------------------------------------------------------------
+
+describe('streamFreeChat — network failure', () => {
+  it('yields server_error on network exception', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('Failed to fetch'));
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toMatchObject({ type: 'error', code: 'server_error' });
+  });
+
+  it('does not increment local prompt counter on network failure', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+    const used = await getFreePromptsUsed();
+    expect(used).toBe(0);
+  });
+
+  it('yields error with code server_error on AbortError', async () => {
+    fetchMock.mockRejectedValueOnce(Object.assign(new Error('AbortError'), { name: 'AbortError' }));
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+    expect(chunks[0]).toMatchObject({ type: 'error', code: 'server_error' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamFreeChat — 401 / 403 responses
+// ---------------------------------------------------------------------------
+
+describe('streamFreeChat — auth and quota errors', () => {
+  it('yields auth_required on 401', async () => {
+    fetchMock.mockResolvedValueOnce(makeErrorResponse(401, 'Unauthorized'));
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'bad-token'));
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toMatchObject({ type: 'error', code: 'auth_required' });
+  });
+
+  it('yields quota_exceeded on 403 with limit_reached body', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeErrorResponse(403, JSON.stringify({ error: 'limit_reached', message: 'Quota hit' })),
+    );
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+    expect(chunks[0]).toMatchObject({ type: 'error', code: 'quota_exceeded' });
+  });
+
+  it('snaps local counter to limit on 403 quota_exceeded', async () => {
+    fetchMock.mockResolvedValueOnce(makeErrorResponse(403, 'free_trial limit_reached'));
+    await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+    expect(chromeMock._localStore[FREE_PROMPTS_USED_KEY]).toBe(FREE_TRIAL_PROMPT_LIMIT);
+  });
+
+  it('yields auth_required on 403 without quota keywords', async () => {
+    fetchMock.mockResolvedValueOnce(makeErrorResponse(403, 'plan gated'));
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+    expect(chunks[0]).toMatchObject({ type: 'error', code: 'auth_required' });
+  });
+
+  it('yields quota_exceeded when body contains "Upgrade" (capital U)', async () => {
+    fetchMock.mockResolvedValueOnce(makeErrorResponse(403, 'Upgrade your plan'));
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+    expect(chunks[0]).toMatchObject({ type: 'error', code: 'quota_exceeded' });
+  });
+
+  it('yields quota_exceeded when body contains prompt_limit', async () => {
+    fetchMock.mockResolvedValueOnce(makeErrorResponse(403, '{"error":"prompt_limit"}'));
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+    expect(chunks[0]).toMatchObject({ type: 'error', code: 'quota_exceeded' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamFreeChat — 5xx / non-OK
+// ---------------------------------------------------------------------------
+
+describe('streamFreeChat — 5xx server error', () => {
+  it('yields server_error on 500 response', async () => {
+    fetchMock.mockResolvedValueOnce(makeErrorResponse(500, 'Internal Server Error'));
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+    expect(chunks[0]).toMatchObject({ type: 'error', code: 'server_error' });
+  });
+
+  it('does not snap counter to limit on 5xx', async () => {
+    fetchMock.mockResolvedValueOnce(makeErrorResponse(502, 'Bad Gateway'));
+    await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+    expect(chromeMock._localStore[FREE_PROMPTS_USED_KEY]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamFreeChat — happy path SSE streaming
+// ---------------------------------------------------------------------------
+
+describe('streamFreeChat — SSE happy path', () => {
+  it('yields text chunks and a done chunk on successful stream', async () => {
+    const sseLines = [
+      JSON.stringify({ choices: [{ delta: { content: 'Hello' }, finish_reason: null }] }),
+      JSON.stringify({ choices: [{ delta: { content: ' world' }, finish_reason: null }] }),
+      JSON.stringify({ choices: [{ delta: { content: '' }, finish_reason: 'stop' }] }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'valid-token'));
+    const textChunks = chunks.filter((c) => c.type === 'text');
+    const doneChunks = chunks.filter((c) => c.type === 'done');
+
+    expect(textChunks).toHaveLength(2);
+    expect((textChunks[0] as { type: 'text'; text: string }).text).toBe('Hello');
+    expect((textChunks[1] as { type: 'text'; text: string }).text).toBe(' world');
+    expect(doneChunks).toHaveLength(1);
+  });
+
+  it('increments local prompt counter on successful stream', async () => {
+    const sseLines = [
+      JSON.stringify({ choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+
+    await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'valid-token'));
+    expect(chromeMock._localStore[FREE_PROMPTS_USED_KEY]).toBe(1);
+  });
+
+  it('increments counter cumulatively across calls', async () => {
+    chromeMock._localStore[FREE_PROMPTS_USED_KEY] = 1;
+    const sseLines = [
+      JSON.stringify({ choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+    await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'valid-token'));
+    expect(chromeMock._localStore[FREE_PROMPTS_USED_KEY]).toBe(2);
+  });
+
+  it('caps counter at FREE_TRIAL_PROMPT_LIMIT even if called beyond limit', async () => {
+    chromeMock._localStore[FREE_PROMPTS_USED_KEY] = FREE_TRIAL_PROMPT_LIMIT;
+    const sseLines = [
+      JSON.stringify({ choices: [{ delta: { content: 'x' }, finish_reason: 'stop' }] }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+    await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'valid-token'));
+    expect(chromeMock._localStore[FREE_PROMPTS_USED_KEY]).toBe(FREE_TRIAL_PROMPT_LIMIT);
+  });
+
+  it('handles [DONE] sentinel without an explicit finish_reason', async () => {
+    const sseLines = [
+      JSON.stringify({ choices: [{ delta: { content: 'hi' }, finish_reason: null }] }),
+      '[DONE]',
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'valid-token'));
+    expect(chunks.some((c) => c.type === 'done')).toBe(true);
+  });
+
+  it('accepts alternative done format: parsed.done = true', async () => {
+    const sseLines = [
+      JSON.stringify({ content: 'hello', done: false }),
+      JSON.stringify({ content: '', done: true }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'valid-token'));
+    expect(chunks.some((c) => c.type === 'done')).toBe(true);
+    const textChunks = chunks.filter((c) => c.type === 'text');
+    expect((textChunks[0] as { type: 'text'; text: string }).text).toBe('hello');
+  });
+
+  it('sends Authorization: Bearer header with the token', async () => {
+    const sseLines = [
+      JSON.stringify({ choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+    await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'my-clerk-token'));
+
+    const [, fetchOpts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = fetchOpts.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer my-clerk-token');
+  });
+
+  it('sends X-Requested-With: XMLHttpRequest header', async () => {
+    const sseLines = [
+      JSON.stringify({ choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+    await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+
+    const [, fetchOpts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = fetchOpts.headers as Record<string, string>;
+    expect(headers['X-Requested-With']).toBe('XMLHttpRequest');
+  });
+
+  it('posts to FREE_TRIAL_ENDPOINT', async () => {
+    const sseLines = [
+      JSON.stringify({ choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+    await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe(FREE_TRIAL_ENDPOINT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamFreeChat — input truncation
+// ---------------------------------------------------------------------------
+
+describe('streamFreeChat — input truncation', () => {
+  it('truncates message content exceeding FREE_TRIAL_MAX_INPUT_CHARS', async () => {
+    const longContent = 'x'.repeat(40_000);
+    const messages: FreeTrialMessage[] = [{ role: 'user', content: longContent }];
+
+    const sseLines = [
+      JSON.stringify({ choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+    await collectChunks(streamFreeChat(messages, 'token'));
+
+    const [, fetchOpts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(fetchOpts.body as string) as {
+      messages: FreeTrialMessage[];
+    };
+    expect(body.messages[0]!.content.length).toBe(32_000);
+  });
+
+  it('does not truncate messages within the char limit', async () => {
+    const shortContent = 'Hello!';
+    const messages: FreeTrialMessage[] = [{ role: 'user', content: shortContent }];
+
+    const sseLines = [
+      JSON.stringify({ choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+    await collectChunks(streamFreeChat(messages, 'token'));
+
+    const [, fetchOpts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(fetchOpts.body as string) as {
+      messages: FreeTrialMessage[];
+    };
+    expect(body.messages[0]!.content).toBe(shortContent);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamFreeChat — inline stream error
+// ---------------------------------------------------------------------------
+
+describe('streamFreeChat — inline stream error', () => {
+  it('yields quota_exceeded on inline stream error with limit_reached code', async () => {
+    const sseLines = [
+      JSON.stringify({
+        error: { message: 'Trial limit reached', code: 'free_trial_limit_reached' },
+      }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+    expect(chunks[0]).toMatchObject({ type: 'error', code: 'quota_exceeded' });
+  });
+
+  it('yields server_error on inline stream error with other code', async () => {
+    const sseLines = [
+      JSON.stringify({
+        error: { message: 'Temporary outage', code: 'service_unavailable' },
+      }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+    expect(chunks[0]).toMatchObject({ type: 'error', code: 'server_error' });
+  });
+
+  it('snaps counter on inline quota error', async () => {
+    const sseLines = [
+      JSON.stringify({
+        error: { message: 'Quota hit', code: 'free_trial_limit_reached' },
+      }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+    await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+    expect(chromeMock._localStore[FREE_PROMPTS_USED_KEY]).toBe(FREE_TRIAL_PROMPT_LIMIT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamFreeChat — abort signal
+// ---------------------------------------------------------------------------
+
+describe('streamFreeChat — abort signal', () => {
+  it('yields server_error when signal is already aborted before fetch', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    fetchMock.mockRejectedValueOnce(
+      Object.assign(new Error('The user aborted a request.'), { name: 'AbortError' }),
+    );
+
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token', controller.signal));
+    expect(chunks[0]).toMatchObject({ type: 'error', code: 'server_error' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamFreeChat — stream ends without explicit finish
+// ---------------------------------------------------------------------------
+
+describe('streamFreeChat — stream ends without finish_reason', () => {
+  it('emits done and increments counter when stream closes after text', async () => {
+    // Send text but no finish_reason — stream just closes
+    const sseLines = [
+      JSON.stringify({ choices: [{ delta: { content: 'hello' }, finish_reason: null }] }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+    expect(chunks.some((c) => c.type === 'done')).toBe(true);
+    expect(chromeMock._localStore[FREE_PROMPTS_USED_KEY]).toBe(1);
+  });
+
+  it('emits done but does NOT increment counter when no text was received', async () => {
+    // Stream closes without any content
+    fetchMock.mockResolvedValueOnce(makeStreamResponse([]));
+    const chunks = await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+    expect(chunks.some((c) => c.type === 'done')).toBe(true);
+    expect(chromeMock._localStore[FREE_PROMPTS_USED_KEY]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamFreeChat — body contains the model from models.json
+// ---------------------------------------------------------------------------
+
+describe('streamFreeChat — model routing', () => {
+  it('sends FREE_TRIAL_MODEL (from models.json) in the request body', async () => {
+    const sseLines = [
+      JSON.stringify({ choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+    await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+
+    const [, fetchOpts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(fetchOpts.body as string) as { model: string };
+    expect(body.model).toBe(FREE_TRIAL_MODEL);
+  });
+
+  it('requests stream=true', async () => {
+    const sseLines = [
+      JSON.stringify({ choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] }),
+    ];
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(sseLines));
+    await collectChunks(streamFreeChat(SAMPLE_MESSAGES, 'token'));
+
+    const [, fetchOpts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(fetchOpts.body as string) as { stream: boolean };
+    expect(body.stream).toBe(true);
+  });
+});

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -21,7 +21,7 @@
   ],
   "host_permissions": ["http://localhost/*", "http://127.0.0.1/*"],
   "content_security_policy": {
-    "extension_pages": "default-src 'self'; script-src 'self'; object-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' http://localhost:* http://127.0.0.1:* https://api.agiworkforce.com https://*.agiworkforce.com; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
+    "extension_pages": "default-src 'self'; script-src 'self'; object-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' http://localhost:* http://127.0.0.1:* https://api.agiworkforce.com https://*.agiworkforce.com https://agiworkforce.com; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
   },
   "background": {
     "service_worker": "src/background.js",

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -19,7 +19,12 @@
     "tabGroups",
     "debugger"
   ],
-  "host_permissions": ["http://localhost/*", "http://127.0.0.1/*"],
+  "host_permissions": [
+    "http://localhost/*",
+    "http://127.0.0.1/*",
+    "https://agiworkforce.com/*",
+    "https://api.agiworkforce.com/*"
+  ],
   "content_security_policy": {
     "extension_pages": "default-src 'self'; script-src 'self'; object-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' http://localhost:* http://127.0.0.1:* https://api.agiworkforce.com https://*.agiworkforce.com https://agiworkforce.com; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
   },

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -64,6 +64,13 @@ import {
   validateBridgeUrl,
   validateShortcutActions,
 } from './background/policy';
+import {
+  getAuthToken,
+  getRemainingFreePrompts,
+  streamFreeChat,
+  FREE_TRIAL_PROMPT_LIMIT,
+  FREE_TRIAL_MODEL,
+} from './features/cloud-bridge/freeTrialClient';
 
 interface BackgroundState {
   isNativeConnected: boolean;
@@ -2863,6 +2870,115 @@ async function handleChatMessage(
   messages.push({ role: 'user', content: userContent });
 
   try {
+    // ── CLOUD FREE-TRIAL PATH ──────────────────────────────────────────────
+    // If the user has a Clerk session token and remaining free prompts, route
+    // through the AGI Cloud economy endpoint BEFORE trying the local bridge.
+    // This is the explicit Cloud path; it never runs for Local/bridge sessions.
+    // Local↔Cloud separation: this runs only when the user has explicitly
+    // signed in (token present). Desktop bridge is still attempted as fallback
+    // if the cloud path is unavailable.
+    const clerkToken = await getAuthToken();
+    if (clerkToken) {
+      const remaining = await getRemainingFreePrompts();
+
+      if (remaining <= 0) {
+        // Quota exhausted — broadcast a special QUOTA_EXCEEDED message so the
+        // side panel can show the upgrade modal.
+        const quotaMsg: import('./types').ChatChunkMessage = {
+          type: 'CHAT_CHUNK',
+          id,
+          text: '',
+          done: true,
+          error: '__QUOTA_EXCEEDED__',
+        };
+        chrome.runtime.sendMessage(quotaMsg).catch(() => {});
+        return;
+      }
+
+      // Attempt cloud stream. On success, return immediately (no bridge fallback).
+      // On network/server error, fall through to the bridge path so the user
+      // still gets a response.
+      let cloudStreamed = false;
+      try {
+        const cloudMessages = messages.map((m) => ({
+          role: m.role as 'user' | 'assistant' | 'system',
+          content: m.content,
+        }));
+
+        for await (const chunk of streamFreeChat(
+          cloudMessages,
+          clerkToken,
+          streamController.signal,
+        )) {
+          if (streamController.signal.aborted) {
+            if (!activeStream.cancelNotified) {
+              activeStream.cancelNotified = true;
+              broadcastChunk('', true, activeStream.cancelRequested ? 'Cancelled.' : undefined);
+            }
+            return;
+          }
+
+          if (chunk.type === 'text') {
+            cloudStreamed = true;
+            broadcastChunk(chunk.text, false);
+          } else if (chunk.type === 'done') {
+            broadcastChunk('', true);
+            // Notify side panel of updated remaining count
+            const newRemaining = await getRemainingFreePrompts();
+            chrome.runtime
+              .sendMessage({
+                type: 'FREE_PROMPTS_UPDATED',
+                remaining: newRemaining,
+                limit: FREE_TRIAL_PROMPT_LIMIT,
+                model: FREE_TRIAL_MODEL,
+              })
+              .catch(() => {});
+            return;
+          } else if (chunk.type === 'error') {
+            if (chunk.code === 'quota_exceeded') {
+              // Server confirmed quota exhausted — show upgrade modal
+              const quotaMsg: import('./types').ChatChunkMessage = {
+                type: 'CHAT_CHUNK',
+                id,
+                text: '',
+                done: true,
+                error: '__QUOTA_EXCEEDED__',
+              };
+              chrome.runtime.sendMessage(quotaMsg).catch(() => {});
+              return;
+            }
+            if (chunk.code === 'auth_required') {
+              // Token invalid — broadcast auth-required signal
+              const authMsg: import('./types').ChatChunkMessage = {
+                type: 'CHAT_CHUNK',
+                id,
+                text: '',
+                done: true,
+                error: '__AUTH_REQUIRED__',
+              };
+              chrome.runtime.sendMessage(authMsg).catch(() => {});
+              return;
+            }
+            // Other error (network / 5xx) — fall through to bridge
+            logger.debug('Free-trial cloud chat error, falling back to bridge', chunk.message);
+            if (cloudStreamed) {
+              // Already emitted some text — close the stream rather than bridging
+              broadcastChunk('', true, chunk.message);
+              return;
+            }
+            break; // fall through to bridge path below
+          }
+        }
+      } catch (cloudErr) {
+        // Unexpected error in the cloud path — fall through to bridge
+        logger.debug(
+          'Free-trial cloud stream threw unexpectedly, falling back to bridge',
+          cloudErr,
+        );
+      }
+    }
+    // ── END CLOUD FREE-TRIAL PATH ──────────────────────────────────────────
+
     // Resolve the bridge URL at call time so it picks up any in-session changes.
     const AGI_API_BASE = await getAgiBridgeBaseUrl();
     if (streamController.signal.aborted) {

--- a/apps/extension/src/background/policy.ts
+++ b/apps/extension/src/background/policy.ts
@@ -377,6 +377,10 @@ export const GATEWAY_URL_ALLOWLIST_EXACT = new Set<string>([
   'https://api.agiworkforce.com',
   'https://gateway.agiworkforce.com',
   'https://staging-api.agiworkforce.com',
+  // Web app origin: hosts the Next.js /api/llm/v1/chat/completions route that
+  // supports free-tier users (reserveFreeTrialPrompt). The Express gateway at
+  // api.agiworkforce.com blocks free-tier users; this origin does not.
+  'https://agiworkforce.com',
 ]);
 
 /**

--- a/apps/extension/src/features/cloud-bridge/InviteCodeModal.ts
+++ b/apps/extension/src/features/cloud-bridge/InviteCodeModal.ts
@@ -40,15 +40,16 @@ function friendlyInviteError(code?: InviteCodeError): string {
 
 function buildModalStyles(): string {
   return `
-    ${getExtensionTokensCss('light').replace(':root', ':host')}
+    ${getExtensionTokensCss('dark').replace(':root', ':host')}
 
-    :host { display:block; }
+    :host { display:block; position:fixed; inset:0; z-index:2147483645; pointer-events:none; }
 
     .agi-modal-backdrop {
-      position:fixed; inset:0; z-index:2147483646;
-      background:rgba(0,0,0,0.45);
+      position:absolute; inset:0;
+      background:rgba(0,0,0,0.55);
       display:flex; align-items:center; justify-content:center;
       font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+      pointer-events:auto;
     }
 
     .agi-modal-backdrop.hidden { display:none; }
@@ -551,7 +552,11 @@ export class InviteCodeModal {
 
     this.host = document.createElement('div');
     this.host.setAttribute('data-agi-cloud-modal', 'true');
-    this.host.style.cssText = 'all:initial;';
+    // Do not use all:initial — it resets display to inline and prevents the
+    // shadow-DOM :host rule (display:block; position:fixed) from taking effect,
+    // which causes the overlay to collapse into normal document flow instead of
+    // covering the viewport. The shadow-DOM stylesheet handles all internal
+    // isolation via the :host rule; no inline reset is needed here.
 
     this.shadow = this.host.attachShadow({ mode: 'open' });
     this.els = buildModalDOM(this.shadow);

--- a/apps/extension/src/features/cloud-bridge/freeTrialClient.ts
+++ b/apps/extension/src/features/cloud-bridge/freeTrialClient.ts
@@ -1,0 +1,472 @@
+/**
+ * freeTrialClient.ts — Economy-tier chat client for signed-in free users.
+ *
+ * Implements the "3 prompts free" tier that mirrors the web Hobby/free experience:
+ *   - 3 cloud chat prompts per user, tracked in chrome.storage.local
+ *   - Routes to POST https://agiworkforce.com/api/llm/v1/chat/completions
+ *     (the Next.js API route that handles free-tier users via
+ *     reserveFreeTrialPrompt — NOT the Express gateway which blocks free users)
+ *   - Economy model: read from models.json taskRouting.chat (gemini-3.1-flash-lite)
+ *   - Streams SSE response back via an async generator
+ *   - Auth: Clerk Bearer token from chrome.storage.session / chrome.storage.local
+ *     (same dual-path as cloudAgentClient.getAuthToken)
+ *
+ * Contract with background.ts:
+ *   1. Call getAuthToken() to check if a token is available
+ *   2. Call getRemainingFreePrompts() to check quota — if 0, caller should
+ *      show the upgrade modal instead of attempting a call
+ *   3. Call streamFreeChat(messages, token) — it decrements the local counter
+ *      and yields text deltas, then a final done signal
+ *   4. If the server returns 403 (quota_exceeded) the local counter is already
+ *      at 0 so the next call will short-circuit without a network round-trip
+ *
+ * QUOTA LOGIC:
+ *   The server is the authoritative gate (reserveFreeTrialPrompt DB write).
+ *   The local counter is a client-side cache that avoids unnecessary round-trips
+ *   and drives the remaining-count UI. On a 403 from the server, we snap the
+ *   local count to 0. On success we decrement locally. On network error or 5xx
+ *   we do NOT decrement (server did not consume the quota slot).
+ *
+ * MODEL:
+ *   Read from models.json providers.managed_cloud.taskRouting.chat at build time.
+ *   Never hardcoded.
+ *
+ * SECURITY:
+ *   - Only posts to FREE_TRIAL_GATEWAY — validated before every fetch
+ *   - Bearer token never logged
+ *   - Input capped at FREE_TRIAL_MAX_INPUT_CHARS to bound server cost
+ */
+
+import modelsJson from '../../../../../packages/types/src/models.json';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * The economy model used for free-trial prompts.
+ * Read from models.json managed_cloud.taskRouting.chat (= gemini-3.1-flash-lite).
+ * Never hardcoded — this constant is the single indirection point.
+ */
+export const FREE_TRIAL_MODEL: string =
+  (modelsJson.providers.managed_cloud.taskRouting as Record<string, string>)['chat'] ??
+  'gemini-3.1-flash-lite';
+
+/**
+ * Number of free prompts per signed-in user.
+ * Mirrors web surface apps/web/lib/free-trial-config.ts FREE_TRIAL_PROMPT_LIMIT = 3.
+ */
+export const FREE_TRIAL_PROMPT_LIMIT = 3;
+
+/**
+ * Character cap on the total user message to bound server cost per free prompt.
+ * Mirrors web FREE_TRIAL_MAX_INPUT_CHARS = 32_000.
+ */
+export const FREE_TRIAL_MAX_INPUT_CHARS = 32_000;
+
+/**
+ * The web app's Next.js API route that handles free-tier users.
+ * This is distinct from https://api.agiworkforce.com/v1/chat/completions
+ * (the Express gateway) which blocks free-tier users with 403.
+ */
+export const FREE_TRIAL_GATEWAY = 'https://agiworkforce.com';
+export const FREE_TRIAL_ENDPOINT = `${FREE_TRIAL_GATEWAY}/api/llm/v1/chat/completions`;
+
+/** chrome.storage.local key for the local free-prompt counter */
+export const FREE_PROMPTS_USED_KEY = 'agi_free_prompts_used';
+
+/** chrome.storage.session / chrome.storage.local key for the Clerk session token */
+const SESSION_TOKEN_KEY = 'agi_clerk_session_token';
+const DEV_TOKEN_KEY = 'agi_dev_bearer_token';
+
+// ─── Auth ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Retrieve the Clerk Bearer token.
+ *
+ * Priority:
+ *   1. chrome.storage.session["agi_clerk_session_token"] — set by the sign-in flow
+ *   2. chrome.storage.local["agi_dev_bearer_token"] — static dev/paste token
+ *   3. null — user must sign in
+ *
+ * Mirrors cloudAgentClient.getAuthToken() so both clients share the same
+ * storage contract. Kept here to allow freeTrialClient to be imported
+ * independently in tests without pulling in the full computer-use module.
+ */
+export async function getAuthToken(): Promise<string | null> {
+  try {
+    if (
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      'session' in chrome.storage &&
+      chrome.storage.session
+    ) {
+      const sess = await (
+        chrome.storage.session as unknown as {
+          get: (keys: string[]) => Promise<Record<string, unknown>>;
+        }
+      ).get([SESSION_TOKEN_KEY]);
+      const token = sess[SESSION_TOKEN_KEY];
+      if (typeof token === 'string' && token.length > 0) return token;
+    }
+  } catch {
+    // unavailable in test environments — fall through
+  }
+
+  try {
+    if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+      const local = await chrome.storage.local.get([DEV_TOKEN_KEY]);
+      const token = local[DEV_TOKEN_KEY];
+      if (typeof token === 'string' && token.length > 0) return token;
+    }
+  } catch {
+    // unavailable in test environments — fall through
+  }
+
+  return null;
+}
+
+/** Store a Clerk session token in chrome.storage.session (cleared on browser close). */
+export async function storeSessionToken(token: string): Promise<void> {
+  try {
+    if (
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      'session' in chrome.storage &&
+      chrome.storage.session
+    ) {
+      await (
+        chrome.storage.session as unknown as {
+          set: (items: Record<string, unknown>) => Promise<void>;
+        }
+      ).set({ [SESSION_TOKEN_KEY]: token });
+      return;
+    }
+  } catch {
+    // fall through to local storage
+  }
+  // Fallback: store in local storage (persists across sessions)
+  try {
+    if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+      await chrome.storage.local.set({ [DEV_TOKEN_KEY]: token });
+    }
+  } catch {
+    // swallow — caller will surface auth prompt on next request
+  }
+}
+
+/** Clear all stored auth tokens (sign-out). */
+export async function clearAuthToken(): Promise<void> {
+  try {
+    if (
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      'session' in chrome.storage &&
+      chrome.storage.session
+    ) {
+      await (
+        chrome.storage.session as unknown as {
+          remove: (keys: string[]) => Promise<void>;
+        }
+      ).remove([SESSION_TOKEN_KEY]);
+    }
+  } catch {
+    // ignore
+  }
+  try {
+    if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+      await chrome.storage.local.remove([DEV_TOKEN_KEY]);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+// ─── Quota helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Read the local free-prompt counter.
+ * Returns how many prompts have been USED (0–3).
+ * Local counter is a cache — server is authoritative on 403.
+ */
+export async function getFreePromptsUsed(): Promise<number> {
+  try {
+    if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+      const result = await chrome.storage.local.get([FREE_PROMPTS_USED_KEY]);
+      const raw = result[FREE_PROMPTS_USED_KEY];
+      if (typeof raw === 'number' && raw >= 0) return Math.min(raw, FREE_TRIAL_PROMPT_LIMIT);
+    }
+  } catch {
+    // storage unavailable
+  }
+  return 0;
+}
+
+/** Number of free prompts the user has remaining. */
+export async function getRemainingFreePrompts(): Promise<number> {
+  const used = await getFreePromptsUsed();
+  return Math.max(0, FREE_TRIAL_PROMPT_LIMIT - used);
+}
+
+/** Increment the local free-prompt counter (called on successful server response). */
+async function incrementPromptsUsed(): Promise<void> {
+  try {
+    if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+      const result = await chrome.storage.local.get([FREE_PROMPTS_USED_KEY]);
+      const current =
+        typeof result[FREE_PROMPTS_USED_KEY] === 'number' ? result[FREE_PROMPTS_USED_KEY] : 0;
+      await chrome.storage.local.set({
+        [FREE_PROMPTS_USED_KEY]: Math.min((current as number) + 1, FREE_TRIAL_PROMPT_LIMIT),
+      });
+    }
+  } catch {
+    // swallow — counter drift is acceptable; server is authoritative
+  }
+}
+
+/** Snap the local counter to the limit (called on 403 quota_exceeded). */
+async function snapPromptCountToLimit(): Promise<void> {
+  try {
+    if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+      await chrome.storage.local.set({ [FREE_PROMPTS_USED_KEY]: FREE_TRIAL_PROMPT_LIMIT });
+    }
+  } catch {
+    // ignore
+  }
+}
+
+// ─── Message shape ────────────────────────────────────────────────────────────
+
+export interface FreeTrialMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+// ─── Stream result ────────────────────────────────────────────────────────────
+
+export type FreeTrialChunk =
+  | { type: 'text'; text: string }
+  | { type: 'done' }
+  | { type: 'error'; message: string; code?: 'quota_exceeded' | 'auth_required' | 'server_error' };
+
+// ─── Core streaming call ──────────────────────────────────────────────────────
+
+/**
+ * Stream a free-trial chat completion from the AGI web gateway.
+ *
+ * Yields FreeTrialChunk items:
+ *   { type: 'text', text }  — incremental content delta
+ *   { type: 'done' }        — stream complete, prompt counted
+ *   { type: 'error', ... }  — terminal error, prompt NOT counted
+ *
+ * The caller is responsible for:
+ *   1. Checking getRemainingFreePrompts() > 0 before calling
+ *   2. Passing a non-null token from getAuthToken()
+ *   3. Handling 'quota_exceeded' by showing the upgrade modal
+ *   4. Handling 'auth_required' by showing the sign-in UI
+ */
+export async function* streamFreeChat(
+  messages: FreeTrialMessage[],
+  token: string,
+  signal?: AbortSignal,
+): AsyncGenerator<FreeTrialChunk> {
+  // Cap total input chars to bound cost per free prompt
+  const cappedMessages = messages.map((m) => ({
+    ...m,
+    content:
+      m.content.length > FREE_TRIAL_MAX_INPUT_CHARS
+        ? m.content.slice(0, FREE_TRIAL_MAX_INPUT_CHARS)
+        : m.content,
+  }));
+
+  let response: Response;
+  try {
+    response = await fetch(FREE_TRIAL_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        // CSRF header required by the web's requireCsrfToken middleware.
+        // For extension-originated requests the Origin header (set by browser
+        // to the extension origin) satisfies same-site checks; some deployments
+        // also check X-Requested-With for XHR-alike detection.
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+      body: JSON.stringify({
+        model: FREE_TRIAL_MODEL,
+        messages: cappedMessages,
+        stream: true,
+        max_tokens: 2000,
+      }),
+      signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      yield { type: 'error', message: 'Cancelled.', code: 'server_error' };
+      return;
+    }
+    yield {
+      type: 'error',
+      message: 'Network error reaching AGI cloud. Check your connection.',
+      code: 'server_error',
+    };
+    return;
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    let body = '';
+    try {
+      body = await response.text();
+    } catch {
+      // ignore
+    }
+
+    // Detect quota-exceeded specifically (server sends 403 with a specific error code)
+    const isQuotaExceeded =
+      response.status === 403 &&
+      (body.includes('limit_reached') ||
+        body.includes('free_trial') ||
+        body.includes('prompt_limit') ||
+        body.includes('Upgrade'));
+
+    if (isQuotaExceeded) {
+      await snapPromptCountToLimit();
+      yield {
+        type: 'error',
+        message: 'Free trial limit reached. Sign in and upgrade to continue.',
+        code: 'quota_exceeded',
+      };
+      return;
+    }
+
+    if (response.status === 401) {
+      yield {
+        type: 'error',
+        message: 'Sign in to use AGI Cloud chat.',
+        code: 'auth_required',
+      };
+      return;
+    }
+
+    // Other 403: plan-gated
+    yield {
+      type: 'error',
+      message: 'Cloud chat requires an AGI account. Sign in to continue.',
+      code: 'auth_required',
+    };
+    return;
+  }
+
+  if (!response.ok) {
+    let errBody = '';
+    try {
+      errBody = await response.text();
+    } catch {
+      // ignore
+    }
+    yield {
+      type: 'error',
+      message: `Cloud gateway error (${response.status}): ${errBody.slice(0, 200)}`,
+      code: 'server_error',
+    };
+    return;
+  }
+
+  // Stream the SSE response
+  const reader = response.body?.getReader();
+  if (!reader) {
+    yield { type: 'error', message: 'No response body from gateway.', code: 'server_error' };
+    return;
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let receivedAnyText = false;
+
+  try {
+    while (true) {
+      if (signal?.aborted) {
+        reader.cancel().catch(() => {});
+        yield { type: 'error', message: 'Cancelled.', code: 'server_error' };
+        return;
+      }
+
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === 'data: [DONE]') continue;
+        if (!trimmed.startsWith('data: ')) continue;
+
+        const dataStr = trimmed.slice(6);
+        try {
+          const parsed = JSON.parse(dataStr) as {
+            choices?: Array<{ delta?: { content?: string }; finish_reason?: string | null }>;
+            content?: string;
+            done?: boolean;
+            error?: { message?: string; code?: string };
+          };
+
+          // Check for inline error in stream (e.g. quota exceeded mid-stream)
+          if (parsed.error) {
+            const errMsg = parsed.error.message ?? 'Gateway error';
+            const errCode = parsed.error.code ?? '';
+            if (errCode.includes('limit_reached') || errCode.includes('free_trial')) {
+              await snapPromptCountToLimit();
+              yield { type: 'error', message: errMsg, code: 'quota_exceeded' };
+              return;
+            }
+            yield { type: 'error', message: errMsg, code: 'server_error' };
+            return;
+          }
+
+          const delta =
+            parsed.choices?.[0]?.delta?.content ??
+            (typeof parsed.content === 'string' ? parsed.content : '');
+
+          if (delta) {
+            receivedAnyText = true;
+            yield { type: 'text', text: delta };
+          }
+
+          if (
+            parsed.done === true ||
+            parsed.choices?.[0]?.finish_reason === 'stop' ||
+            parsed.choices?.[0]?.finish_reason === 'length'
+          ) {
+            // Success path — increment local counter
+            if (receivedAnyText) {
+              await incrementPromptsUsed();
+            }
+            yield { type: 'done' };
+            return;
+          }
+        } catch {
+          // Non-JSON or malformed SSE line — skip
+        }
+      }
+    }
+
+    // Stream ended without explicit [DONE] — treat as success if we got text
+    if (receivedAnyText) {
+      await incrementPromptsUsed();
+    }
+    yield { type: 'done' };
+  } catch (err) {
+    reader.cancel().catch(() => {});
+    if (err instanceof Error && err.name === 'AbortError') {
+      yield { type: 'error', message: 'Cancelled.', code: 'server_error' };
+      return;
+    }
+    yield {
+      type: 'error',
+      message: err instanceof Error ? err.message : 'Stream read error.',
+      code: 'server_error',
+    };
+  } finally {
+    reader.cancel().catch(() => {});
+  }
+}

--- a/apps/extension/src/features/computer-use/cloudAgentClient.ts
+++ b/apps/extension/src/features/computer-use/cloudAgentClient.ts
@@ -391,7 +391,29 @@ export async function callCloud(
 
   if (!response.ok) {
     const errText = await response.text().catch(() => '');
-    throw new Error(`callCloud: gateway returned ${response.status}: ${errText}`);
+    // Detect the managed-compute private-beta gate (403 with public_launch_blocked).
+    // This gate is controlled by the AGI_MANAGED_COMPUTE_PRIVATE_BETA=1 server env
+    // var and is not account-specific — the server must have it set for ANY account
+    // to use the computer-use agent. When the founder's demo server has the env var
+    // set, this 403 will not occur. Providing a clear error here avoids confusion.
+    if (
+      response.status === 403 &&
+      (errText.includes('public_launch_blocked') ||
+        errText.includes('managed_compute_private_beta'))
+    ) {
+      throw new Error(
+        'callCloud: managed-compute private-beta gate active (403). ' +
+          'The server requires AGI_MANAGED_COMPUTE_PRIVATE_BETA=1 to be set. ' +
+          'Contact the server admin to enable this for the demo deployment.',
+      );
+    }
+    if (response.status === 401) {
+      throw new Error(
+        'callCloud: authentication failed (401). ' +
+          'Paste a fresh Clerk session token via AGI Cloud sign-in in the drawer.',
+      );
+    }
+    throw new Error(`callCloud: gateway returned ${response.status}: ${errText.slice(0, 300)}`);
   }
 
   // Consume SSE stream

--- a/apps/extension/src/features/computer-use/cloudAgentClient.ts
+++ b/apps/extension/src/features/computer-use/cloudAgentClient.ts
@@ -369,7 +369,9 @@ export async function callCloud(
     throw new Error(`callCloud: gateway URL not in allowlist: ${gatewayBase}`);
   }
 
-  const endpoint = `${validatedBase}/v1/chat/completions`;
+  // The gateway mounts the LLM proxy under /api/llm/v1 (services/api-gateway), so the
+  // chat-completions route is /api/llm/v1/chat/completions — a bare /v1/... 404s.
+  const endpoint = `${validatedBase}/api/llm/v1/chat/completions`;
 
   const body = JSON.stringify({
     model: COMPUTER_USE_MODEL,
@@ -385,6 +387,11 @@ export async function callCloud(
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
+      // Gateway validateCsrf requires this header on every POST (rejects 403 CSRF_ERROR otherwise).
+      'X-Requested-With': 'XMLHttpRequest',
+      // Managed-compute gate needs BOTH the server env AGI_MANAGED_COMPUTE_PRIVATE_BETA=1 AND
+      // this request header; without it the gate returns 403 not_private_beta even when env is set.
+      'x-agi-managed-compute-beta': '1',
     },
     body,
   });
@@ -399,12 +406,14 @@ export async function callCloud(
     if (
       response.status === 403 &&
       (errText.includes('public_launch_blocked') ||
-        errText.includes('managed_compute_private_beta'))
+        errText.includes('managed_compute_private_beta') ||
+        errText.includes('not_private_beta'))
     ) {
       throw new Error(
         'callCloud: managed-compute private-beta gate active (403). ' +
-          'The server requires AGI_MANAGED_COMPUTE_PRIVATE_BETA=1 to be set. ' +
-          'Contact the server admin to enable this for the demo deployment.',
+          'The server requires AGI_MANAGED_COMPUTE_PRIVATE_BETA=1 (env) and this client now ' +
+          'sends the x-agi-managed-compute-beta:1 header. If still 403, the account is not on a ' +
+          'paid (Pro) plan — gpt-5.4-mini computer-use requires Pro.',
       );
     }
     if (response.status === 401) {

--- a/apps/extension/src/side_panel.ts
+++ b/apps/extension/src/side_panel.ts
@@ -6,6 +6,7 @@ import {
   PROVIDER_DISPLAY,
   CAPABILITY_LABEL,
   getModelMetadataById,
+  getPickerModelTier,
   type ProviderId,
   type CapabilityTier,
 } from '@agiworkforce/types';
@@ -1569,6 +1570,22 @@ function injectStyles(): void {
     }
     .sp-model-option.selected .sp-model-option-sublabel { color: var(--agi-ext-accent); opacity: 0.7; }
     .sp-model-option:hover .sp-model-option-sublabel { color: var(--agi-ext-text-muted); }
+
+    /* ── Free-tier model gating: Upgrade badge on premium models ── */
+    .sp-model-option.premium-gated { opacity: 0.75; }
+    .sp-model-option.premium-gated:hover { background: var(--agi-ext-hover); color: var(--agi-ext-text); opacity: 1; cursor: pointer; }
+    .sp-model-upgrade-tag {
+      font-size: 8px;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: #fff;
+      background: linear-gradient(90deg, #f59e0b, #f97316);
+      border-radius: 3px;
+      padding: 1px 5px;
+      flex-shrink: 0;
+      white-space: nowrap;
+    }
 
     /* "Best (auto)" option — visually distinct row */
     .sp-model-option-auto {
@@ -3414,10 +3431,20 @@ function buildUI(): void {
    */
   function buildModelOptionRow(m: SidePanelModelOption, isSelected: boolean): HTMLElement {
     const isAuto = m.value === 'auto';
+
+    // FREE-TIER MODEL GATING:
+    // Economy models (in tierAllowedModels.economy) are selectable by all users.
+    // Pro-additions and flagship models are visible but gated with an "Upgrade"
+    // badge. Clicking a gated model opens the pricing/waitlist page instead of
+    // selecting the model. The "auto" option is always freely selectable.
+    const pickerTier = isAuto ? 'economy' : getPickerModelTier(m.value);
+    const isPremiumGated = !isAuto && (pickerTier === 'balanced' || pickerTier === 'premium');
+
     const classes = [
       'sp-model-option',
       isSelected ? 'selected' : '',
       isAuto ? 'sp-model-option-auto' : '',
+      isPremiumGated ? 'premium-gated' : '',
     ]
       .filter(Boolean)
       .join(' ');
@@ -3460,17 +3487,28 @@ function buildUI(): void {
     }
     opt.appendChild(textBlock);
 
-    // Checkmark
-    opt.appendChild(el('span', { class: 'sp-model-option-check' }, isSelected ? '✓' : ''));
-
-    opt.addEventListener('click', () => {
-      currentModelValue = m.value;
-      chrome.storage.local.set({ agi_model: m.value }).catch(() => {});
-      updateModelBadge(m.value);
-      renderModelDropdown();
-      modelDropdownEl.classList.remove('open');
-      modelSelectorBtn.classList.remove('open');
-    });
+    if (isPremiumGated) {
+      // Show "Upgrade" badge instead of checkmark — clicking opens pricing page.
+      opt.appendChild(el('span', { class: 'sp-model-upgrade-tag' }, 'Upgrade'));
+      opt.addEventListener('click', () => {
+        // Close dropdown
+        modelDropdownEl.classList.remove('open');
+        modelSelectorBtn.classList.remove('open');
+        // Navigate to pricing/waitlist page
+        chrome.tabs.create({ url: 'https://agiworkforce.com/pricing' }).catch(() => {});
+      });
+    } else {
+      // Checkmark for economy/auto (selectable) models
+      opt.appendChild(el('span', { class: 'sp-model-option-check' }, isSelected ? '✓' : ''));
+      opt.addEventListener('click', () => {
+        currentModelValue = m.value;
+        chrome.storage.local.set({ agi_model: m.value }).catch(() => {});
+        updateModelBadge(m.value);
+        renderModelDropdown();
+        modelDropdownEl.classList.remove('open');
+        modelSelectorBtn.classList.remove('open');
+      });
+    }
 
     return opt;
   }
@@ -3577,7 +3615,16 @@ function buildUI(): void {
     if (chrome.runtime.lastError) return;
     const stored = result['agi_model'] as string | undefined;
     if (stored) {
-      currentModelValue = normalizeModelId(stored) ?? stored;
+      const resolved = normalizeModelId(stored) ?? stored;
+      // FREE-TIER GATE: if the previously stored model is premium-gated, reset
+      // to 'auto' so the user cannot bypass the tier check via stale storage.
+      const storedTier = getPickerModelTier(resolved);
+      if (storedTier === 'balanced' || storedTier === 'premium') {
+        currentModelValue = 'auto';
+        chrome.storage.local.remove('agi_model').catch(() => {});
+      } else {
+        currentModelValue = resolved;
+      }
     }
     const storedThinking = result['agi_thinking_enabled'] as boolean | undefined;
     if (storedThinking !== undefined) {

--- a/apps/extension/src/side_panel.ts
+++ b/apps/extension/src/side_panel.ts
@@ -64,6 +64,14 @@ import {
 } from './features/native-bridge/pairing';
 import { isMemoryItem, MEMORY_STORAGE_KEY } from './background/memory-bridge';
 import { mountInviteCodeModal } from './features/cloud-bridge/InviteCodeModal';
+import {
+  getAuthToken,
+  getRemainingFreePrompts,
+  storeSessionToken,
+  clearAuthToken,
+  FREE_TRIAL_PROMPT_LIMIT,
+  FREE_TRIAL_MODEL,
+} from './features/cloud-bridge/freeTrialClient';
 
 const extensionSendQueue = getExtensionSendQueue();
 
@@ -76,6 +84,17 @@ const SP_SITE_ALLOWLIST_KEY = 'agi_site_allowlist';
 /** Session timer for the stats footer in the drawer */
 let _drawerSessionStart = Date.now();
 let _drawerSessionTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Module-level reference to the cloud account UI refresh function.
+ * Populated by buildUI() after the inner function is created so that the
+ * chrome.runtime.onMessage listener (which runs at module scope, outside
+ * buildUI's closure) can call it to update the quota bar and header badge
+ * in response to FREE_PROMPTS_UPDATED / __QUOTA_EXCEEDED__ / __AUTH_REQUIRED__.
+ */
+let refreshCloudAccountUI: () => Promise<void> = async () => {
+  /* no-op until buildUI() initialises the real implementation */
+};
 
 /**
  * Side-panel UI message shape.
@@ -313,6 +332,8 @@ function injectStyles(): void {
       display: flex;
       align-items: center;
       justify-content: center;
+      /* currentColor for the 11 gray spokes; amber spoke is hard-wired in SVG */
+      color: var(--agi-ext-text-muted);
     }
     #sp-logo svg {
       width: 24px;
@@ -1503,7 +1524,7 @@ function injectStyles(): void {
     #sp-model-selector-btn:focus-visible { outline: 2px solid var(--agi-ext-focus); outline-offset: 2px; }
     #sp-model-selector-btn .sp-chevron { font-size: 8px; transition: transform 0.15s; }
     #sp-model-selector-btn.open .sp-chevron { transform: rotate(180deg); }
-    #sp-model-dropdown { display: none; position: absolute; top: 100%; right: 0; margin-top: 4px; min-width: 180px; max-height: 280px; overflow-y: auto; background: var(--agi-ext-surface); border: 1px solid var(--agi-ext-border); border-radius: 8px; padding: 4px; z-index: 200; box-shadow: 0 4px 16px var(--agi-ext-modal-shadow); }
+    #sp-model-dropdown { display: none; position: absolute; top: 100%; left: 0; right: auto; margin-top: 4px; min-width: 200px; max-width: calc(100vw - 24px); max-height: 280px; overflow-y: auto; background: var(--agi-ext-surface); border: 1px solid var(--agi-ext-border); border-radius: 8px; padding: 4px; z-index: 200; box-shadow: 0 4px 16px var(--agi-ext-modal-shadow); }
     #sp-model-dropdown.open { display: block; }
     .sp-model-option { display: flex; align-items: center; gap: 8px; padding: 7px 9px; border-radius: 5px; cursor: pointer; transition: background 0.12s; font-size: 11px; color: var(--agi-ext-text-muted); }
     .sp-model-option:hover { background: var(--agi-ext-hover); color: var(--agi-ext-text); }
@@ -2094,6 +2115,208 @@ function injectStyles(): void {
       transition: background 0.15s, border-color 0.15s;
     }
     .sp-drawer-cloud-btn:hover { background: color-mix(in srgb, var(--agi-ext-accent) 20%, transparent); border-color: var(--agi-ext-accent); }
+
+    /* ── AGI Cloud sign-in / quota UI ── */
+    .sp-cloud-account {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .sp-cloud-signed-in {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .sp-cloud-avatar {
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      background: color-mix(in srgb, var(--agi-ext-accent) 20%, transparent);
+      border: 1px solid color-mix(in srgb, var(--agi-ext-accent) 35%, transparent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 11px;
+      font-weight: 700;
+      color: var(--agi-ext-accent);
+      flex-shrink: 0;
+    }
+    .sp-cloud-user-info {
+      flex: 1;
+      min-width: 0;
+    }
+    .sp-cloud-user-label {
+      font-size: 11px;
+      font-weight: 600;
+      color: var(--agi-ext-text);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .sp-cloud-user-tier {
+      font-size: 10px;
+      color: var(--agi-ext-text-muted);
+    }
+    .sp-cloud-signout-btn {
+      background: transparent;
+      border: 1px solid var(--agi-ext-border-strong);
+      border-radius: 5px;
+      color: var(--agi-ext-text-muted);
+      font-size: 10px;
+      padding: 3px 7px;
+      cursor: pointer;
+      flex-shrink: 0;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .sp-cloud-signout-btn:hover { color: var(--agi-ext-danger); border-color: var(--agi-ext-danger); }
+
+    /* Quota bar */
+    .sp-quota-bar-wrap {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .sp-quota-bar-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-size: 10px;
+      color: var(--agi-ext-text-muted);
+    }
+    .sp-quota-bar-model {
+      font-size: 9px;
+      color: var(--agi-ext-text-muted);
+      opacity: 0.7;
+    }
+    .sp-quota-bar-bg {
+      height: 4px;
+      border-radius: 2px;
+      background: var(--agi-ext-border);
+      overflow: hidden;
+    }
+    .sp-quota-bar-fill {
+      height: 100%;
+      border-radius: 2px;
+      background: var(--agi-ext-accent);
+      transition: width 0.3s ease;
+    }
+    .sp-quota-bar-fill.exhausted {
+      background: var(--agi-ext-danger);
+    }
+    .sp-quota-upgrade-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+    }
+    .sp-quota-upgrade-btn {
+      font-size: 10px;
+      font-weight: 600;
+      color: var(--agi-ext-accent);
+      background: color-mix(in srgb, var(--agi-ext-accent) 10%, transparent);
+      border: 1px solid color-mix(in srgb, var(--agi-ext-accent) 25%, transparent);
+      border-radius: 5px;
+      padding: 3px 8px;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: background 0.12s;
+    }
+    .sp-quota-upgrade-btn:hover { background: color-mix(in srgb, var(--agi-ext-accent) 18%, transparent); }
+
+    /* Sign-in prompt (when not signed in) */
+    .sp-cloud-signin-prompt {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .sp-cloud-signin-desc {
+      font-size: 11px;
+      color: var(--agi-ext-text-muted);
+      line-height: 1.45;
+    }
+    .sp-cloud-signin-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+      width: 100%;
+      background: var(--agi-ext-accent);
+      border: none;
+      border-radius: 7px;
+      color: var(--agi-ext-on-accent);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 8px 14px;
+      cursor: pointer;
+      transition: opacity 0.15s;
+    }
+    .sp-cloud-signin-btn:hover { opacity: 0.88; }
+    .sp-cloud-token-row {
+      display: flex;
+      gap: 6px;
+      align-items: center;
+    }
+    .sp-cloud-token-input {
+      flex: 1;
+      background: var(--agi-ext-bg);
+      border: 1px solid var(--agi-ext-border-strong);
+      border-radius: 6px;
+      color: var(--agi-ext-text);
+      font-size: 10px;
+      font-family: 'SF Mono', Monaco, Consolas, monospace;
+      padding: 5px 8px;
+      outline: none;
+      min-width: 0;
+      transition: border-color 0.15s;
+    }
+    .sp-cloud-token-input:focus { border-color: var(--agi-ext-focus); }
+    .sp-cloud-token-input::placeholder { color: var(--agi-ext-text-muted); opacity: 0.55; }
+    .sp-cloud-token-save-btn {
+      background: var(--agi-ext-surface);
+      border: 1px solid var(--agi-ext-border-strong);
+      border-radius: 6px;
+      color: var(--agi-ext-text);
+      font-size: 10px;
+      font-weight: 600;
+      padding: 5px 9px;
+      cursor: pointer;
+      flex-shrink: 0;
+      transition: background 0.12s;
+    }
+    .sp-cloud-token-save-btn:hover { background: var(--agi-ext-hover); }
+    .sp-cloud-token-hint {
+      font-size: 9px;
+      color: var(--agi-ext-text-muted);
+      opacity: 0.7;
+      line-height: 1.4;
+    }
+
+    /* Quota badge in the chat header */
+    #sp-quota-badge {
+      display: none;
+      align-items: center;
+      gap: 4px;
+      font-size: 10px;
+      font-weight: 600;
+      border-radius: 10px;
+      padding: 2px 7px;
+      white-space: nowrap;
+      cursor: pointer;
+      transition: opacity 0.15s;
+    }
+    #sp-quota-badge.visible { display: flex; }
+    #sp-quota-badge.has-prompts {
+      background: color-mix(in srgb, var(--agi-ext-accent) 12%, transparent);
+      color: var(--agi-ext-accent);
+      border: 1px solid color-mix(in srgb, var(--agi-ext-accent) 28%, transparent);
+    }
+    #sp-quota-badge.exhausted {
+      background: var(--agi-ext-danger-bg);
+      color: var(--agi-ext-danger);
+      border: 1px solid var(--agi-ext-danger-border);
+    }
+    #sp-quota-badge:hover { opacity: 0.8; }
+
     /* Drawer footer */
     #sp-drawer-footer {
       padding: 10px 14px;
@@ -3134,13 +3357,22 @@ function buildUI(): void {
   // DOMParser-based import. Same end result — static SVG literal rendered
   // into the wrapper — but no HTML parser involved.
   const logoEl = el('div', { id: 'sp-logo' });
-  const logoSvg = `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-    <rect width="24" height="24" rx="6" fill="url(#logoGrad)"/>
-    <circle cx="12" cy="9" r="3" stroke="white" stroke-width="1.5"/>
-    <path d="M6 19c0-3.314 2.686-5 6-5s6 1.686 6 5" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-    <defs><linearGradient id="logoGrad" x1="0" y1="0" x2="24" y2="24" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#21808d"/><stop offset="1" stop-color="#da7756"/>
-    </linearGradient></defs>
+  // AGI brand mark: 12 spokes radiating from center (inner r=4.6, outer r=9).
+  // Spoke at index 0 (12 o'clock) uses amber/terra accent; others inherit text
+  // color via currentColor. Geometry mirrors packages/ui/src/AgiMark.tsx.
+  const logoSvg = `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="AGI" role="img">
+    <line x1="12" y1="7.4" x2="12" y2="3" stroke="var(--agi-ext-accent-secondary,#da7756)" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="14.3" y1="8.016" x2="16.5" y2="4.206" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="15.984" y1="9.7" x2="19.794" y2="7.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="16.6" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="15.984" y1="14.3" x2="19.794" y2="16.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="14.3" y1="15.984" x2="16.5" y2="19.794" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="12" y1="16.6" x2="12" y2="21" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="9.7" y1="15.984" x2="7.5" y2="19.794" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="8.016" y1="14.3" x2="4.206" y2="16.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="7.4" y1="12" x2="3" y2="12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="8.016" y1="9.7" x2="4.206" y2="7.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="9.7" y1="8.016" x2="7.5" y2="4.206" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
   </svg>`;
   appendSvgString(logoEl, logoSvg);
   headerLeft.appendChild(logoEl);
@@ -3395,6 +3627,19 @@ function buildUI(): void {
     renderMessages();
   });
   headerRight.appendChild(newChatBtn);
+
+  // ── Quota badge (cloud free-prompts remaining) ─────────────────────────────
+  // Built in the drawer section block but inserted into the header here so it
+  // appears between the new-chat button and the menu button.
+  // `quotaBadgeEl` is defined later when the drawer is built; we use a late
+  // reference via getElementById at reveal time so the element is available
+  // after the initial DOM pass. For the header we create a placeholder span
+  // that becomes the actual badge once the drawer code runs.
+  // NOTE: quotaBadgeEl is declared via `let` in the drawer closure below and
+  // appended to headerRight there. We reserve the slot here via a wrapper so
+  // the layout order is correct.
+  const quotaBadgeSlot = el('span', { id: 'sp-quota-badge-slot' });
+  headerRight.appendChild(quotaBadgeSlot);
 
   // ── ⋮ menu button (opens settings drawer) ─────────────────────────────────
   const menuBtn = el('button', {
@@ -4371,18 +4616,150 @@ function buildUI(): void {
     if (e.key === 'Enter') drawerSaveBridgeUrl();
   });
 
-  // ── Section 8: Unlock AGI Cloud ───────────────────────────────────────────
+  // ── Section 8: AGI Cloud (sign-in + free-trial quota) ────────────────────
   const cloudSection = el('div', { class: 'sp-drawer-section' });
   cloudSection.appendChild(el('div', { class: 'sp-drawer-section-title' }, 'AGI Cloud'));
+
+  // Container that swaps between signed-in and signed-out views
+  const cloudAccountEl = el('div', { class: 'sp-cloud-account', id: 'sp-cloud-account' });
+
+  // ── Signed-out view ──────────────────────────────────────────────────────
+  const signinPrompt = el('div', {
+    class: 'sp-cloud-signin-prompt',
+    id: 'sp-cloud-signin-prompt',
+  });
+  signinPrompt.appendChild(
+    el(
+      'span',
+      { class: 'sp-cloud-signin-desc' },
+      'Sign in to get 3 free cloud chat prompts routed through AGI economy models.',
+    ),
+  );
+
+  const signinBtn = el('button', { class: 'sp-cloud-signin-btn', id: 'sp-cloud-signin-btn' });
+  signinBtn.textContent = 'Sign in to AGI Cloud';
+  signinBtn.addEventListener('click', () => {
+    // Open the web sign-in page. After signing in, the user can copy their
+    // session token from the developer tools or the extension token page.
+    chrome.tabs.create({ url: 'https://agiworkforce.com/sign-in' }).catch(() => {});
+  });
+  signinPrompt.appendChild(signinBtn);
+
+  // Token paste row (for users who are already signed in on web)
+  const tokenRow = el('div', { class: 'sp-cloud-token-row' });
+  const tokenInput = el('input', {
+    type: 'password',
+    class: 'sp-cloud-token-input',
+    id: 'sp-cloud-token-input',
+    placeholder: 'Paste Clerk session token…',
+    autocomplete: 'off',
+    spellcheck: 'false',
+  }) as HTMLInputElement;
+  const tokenSaveBtn = el(
+    'button',
+    { class: 'sp-cloud-token-save-btn', id: 'sp-cloud-token-save-btn' },
+    'Save',
+  );
+  tokenRow.appendChild(tokenInput);
+  tokenRow.appendChild(tokenSaveBtn);
+  signinPrompt.appendChild(tokenRow);
+  signinPrompt.appendChild(
+    el(
+      'span',
+      { class: 'sp-cloud-token-hint' },
+      'Already signed in on agiworkforce.com? Copy your token from Account settings.',
+    ),
+  );
+
+  // ── Signed-in view ───────────────────────────────────────────────────────
+  const signedInView = el('div', {
+    class: 'sp-cloud-signed-in',
+    id: 'sp-cloud-signed-in',
+    style: 'display:none',
+  });
+  const avatarEl = el('div', { class: 'sp-cloud-avatar', id: 'sp-cloud-avatar' }, 'A');
+  const userInfoEl = el('div', { class: 'sp-cloud-user-info' });
+  const userLabelEl = el('div', {
+    class: 'sp-cloud-user-label',
+    id: 'sp-cloud-user-label',
+  });
+  userLabelEl.textContent = 'AGI Account';
+  const userTierEl = el('div', { class: 'sp-cloud-user-tier', id: 'sp-cloud-user-tier' });
+  userTierEl.textContent = 'Free tier';
+  userInfoEl.appendChild(userLabelEl);
+  userInfoEl.appendChild(userTierEl);
+  const signoutBtn = el(
+    'button',
+    { class: 'sp-cloud-signout-btn', id: 'sp-cloud-signout-btn' },
+    'Sign out',
+  );
+  signedInView.appendChild(avatarEl);
+  signedInView.appendChild(userInfoEl);
+  signedInView.appendChild(signoutBtn);
+
+  // ── Quota bar ────────────────────────────────────────────────────────────
+  const quotaWrap = el('div', {
+    class: 'sp-quota-bar-wrap',
+    id: 'sp-quota-bar-wrap',
+    style: 'display:none',
+  });
+  const quotaTopRow = el('div', { class: 'sp-quota-bar-row' });
+  const quotaLabel = el('span', { id: 'sp-quota-label' }, 'Free prompts');
+  const quotaCount = el('span', { id: 'sp-quota-count' }, `0 / ${FREE_TRIAL_PROMPT_LIMIT}`);
+  quotaTopRow.appendChild(quotaLabel);
+  quotaTopRow.appendChild(quotaCount);
+  const quotaBarBg = el('div', { class: 'sp-quota-bar-bg' });
+  const quotaBarFill = el('div', {
+    class: 'sp-quota-bar-fill',
+    id: 'sp-quota-bar-fill',
+    style: 'width:0%',
+  });
+  quotaBarBg.appendChild(quotaBarFill);
+  const quotaModelRow = el('div', { class: 'sp-quota-bar-row' });
+  const quotaModelLabel = el(
+    'span',
+    { class: 'sp-quota-bar-model', id: 'sp-quota-model-label' },
+    `Model: ${FREE_TRIAL_MODEL}`,
+  );
+  quotaModelRow.appendChild(quotaModelLabel);
+  quotaWrap.appendChild(quotaTopRow);
+  quotaWrap.appendChild(quotaBarBg);
+  quotaWrap.appendChild(quotaModelRow);
+
+  // Upgrade row (shown when quota exhausted)
+  const quotaUpgradeRow = el('div', {
+    class: 'sp-quota-upgrade-row',
+    id: 'sp-quota-upgrade-row',
+    style: 'display:none',
+  });
+  const quotaExhaustedLabel = el(
+    'span',
+    { style: 'font-size:10px;color:var(--agi-ext-danger)' },
+    'Free prompts used',
+  );
+  const quotaUpgradeBtn = el(
+    'button',
+    { class: 'sp-quota-upgrade-btn', id: 'sp-quota-upgrade-btn' },
+    'Upgrade',
+  );
+  quotaUpgradeRow.appendChild(quotaExhaustedLabel);
+  quotaUpgradeRow.appendChild(quotaUpgradeBtn);
+  quotaWrap.appendChild(quotaUpgradeRow);
+
+  cloudAccountEl.appendChild(signinPrompt);
+  cloudAccountEl.appendChild(signedInView);
+  cloudAccountEl.appendChild(quotaWrap);
+  cloudSection.appendChild(cloudAccountEl);
+  drawerBody.appendChild(cloudSection);
+
+  // ── "Unlock AGI Cloud" button (invite-code path, kept below sign-in) ────
+  let drawerCloudModal: ReturnType<typeof mountInviteCodeModal> | null = null;
+  const inviteCodeSection = el('div', { class: 'sp-drawer-section' });
   const drawerCloudBtn = el(
     'button',
-    {
-      class: 'sp-drawer-cloud-btn',
-      id: 'sp-drawer-cloud-btn',
-    },
-    'Unlock AGI Cloud',
+    { class: 'sp-drawer-cloud-btn', id: 'sp-drawer-cloud-btn' },
+    'Enter invite code',
   );
-  let drawerCloudModal: ReturnType<typeof mountInviteCodeModal> | null = null;
   drawerCloudBtn.addEventListener('click', () => {
     if (!drawerCloudModal) {
       drawerCloudModal = mountInviteCodeModal(document.body, {
@@ -4391,15 +4768,106 @@ function buildUI(): void {
         defaultTab: 'invite',
         onClose: () => drawerCloudModal?.update({ open: false }),
         onRedeemed: (_inviteId) => {
-          // Could refresh tier display here in future
+          void refreshCloudAccountUI();
         },
       });
     } else {
       drawerCloudModal.show();
     }
   });
-  cloudSection.appendChild(drawerCloudBtn);
-  drawerBody.appendChild(cloudSection);
+  inviteCodeSection.appendChild(drawerCloudBtn);
+  drawerBody.appendChild(inviteCodeSection);
+
+  // ── Quota badge in header (click opens drawer to cloud section) ──────────
+  // Insert into the slot reserved in the header above.
+  const quotaBadgeEl = el('div', {
+    id: 'sp-quota-badge',
+    title: 'AGI Cloud free prompts',
+    style: 'cursor:pointer',
+  });
+  quotaBadgeEl.addEventListener('click', () => {
+    const drawerEl = document.getElementById('sp-drawer');
+    if (drawerEl && !drawerEl.classList.contains('open')) {
+      drawerEl.classList.add('open');
+      const overlayEl = document.getElementById('sp-drawer-overlay');
+      if (overlayEl) overlayEl.classList.add('open');
+    }
+  });
+  // Attach to the slot created in the header section above
+  const quotaSlot = document.getElementById('sp-quota-badge-slot');
+  if (quotaSlot) quotaSlot.replaceWith(quotaBadgeEl);
+  else document.body.appendChild(quotaBadgeEl);
+
+  // ── Cloud UI state helpers ───────────────────────────────────────────────
+  // Wire the module-level placeholder to the real implementation (which closes
+  // over signinPrompt, signedInView, quotaWrap, quotaBadgeEl, etc.).
+  refreshCloudAccountUI = async function (): Promise<void> {
+    const token = await getAuthToken();
+    if (!token) {
+      // Signed out
+      signinPrompt.style.display = '';
+      signedInView.style.display = 'none';
+      quotaWrap.style.display = 'none';
+      quotaBadgeEl.classList.remove('visible', 'has-prompts', 'exhausted');
+      return;
+    }
+
+    // Signed in
+    signinPrompt.style.display = 'none';
+    signedInView.style.display = '';
+    quotaWrap.style.display = '';
+
+    const remaining = await getRemainingFreePrompts();
+    const used = FREE_TRIAL_PROMPT_LIMIT - remaining;
+    const pct = Math.round((used / FREE_TRIAL_PROMPT_LIMIT) * 100);
+
+    quotaCount.textContent = `${remaining} / ${FREE_TRIAL_PROMPT_LIMIT} remaining`;
+    (quotaBarFill as HTMLElement).style.width = `${pct}%`;
+    if (remaining === 0) {
+      (quotaBarFill as HTMLElement).classList.add('exhausted');
+      quotaUpgradeRow.style.display = '';
+    } else {
+      (quotaBarFill as HTMLElement).classList.remove('exhausted');
+      quotaUpgradeRow.style.display = 'none';
+    }
+
+    // Header badge
+    quotaBadgeEl.classList.add('visible');
+    quotaBadgeEl.classList.remove('has-prompts', 'exhausted');
+    if (remaining > 0) {
+      quotaBadgeEl.textContent = `${remaining} free`;
+      quotaBadgeEl.classList.add('has-prompts');
+    } else {
+      quotaBadgeEl.textContent = 'Upgrade';
+      quotaBadgeEl.classList.add('exhausted');
+    }
+  };
+
+  // Token save handler
+  tokenSaveBtn.addEventListener('click', async () => {
+    const raw = tokenInput.value.trim();
+    if (!raw) return;
+    await storeSessionToken(raw);
+    tokenInput.value = '';
+    await refreshCloudAccountUI();
+  });
+  tokenInput.addEventListener('keydown', (e: KeyboardEvent) => {
+    if (e.key === 'Enter') tokenSaveBtn.click();
+  });
+
+  // Sign-out handler
+  signoutBtn.addEventListener('click', async () => {
+    await clearAuthToken();
+    await refreshCloudAccountUI();
+  });
+
+  // Upgrade button — open agiworkforce.com pricing
+  quotaUpgradeBtn.addEventListener('click', () => {
+    chrome.tabs.create({ url: 'https://agiworkforce.com/pricing' }).catch(() => {});
+  });
+
+  // Initial load
+  void refreshCloudAccountUI();
 
   drawer.appendChild(drawerBody);
 
@@ -5925,6 +6393,14 @@ chrome.runtime.onMessage.addListener((msg: unknown) => {
     return;
   }
 
+  // Cloud free-trial quota refresh — background emits this after each streamed
+  // response so the quota bar and header badge stay current without a full page
+  // reload.
+  if (envelope.type === 'FREE_PROMPTS_UPDATED') {
+    void refreshCloudAccountUI();
+    return;
+  }
+
   // Live connection-status updates from the background service worker.
   // Background now also broadcasts these via chrome.runtime.sendMessage so
   // extension views (side panel, popup) receive them — not just content scripts.
@@ -5947,6 +6423,54 @@ chrome.runtime.onMessage.addListener((msg: unknown) => {
   if (chunk.id !== _ctx.currentStreamId) return;
 
   if (chunk.error) {
+    // Cloud free-trial sentinels: show actionable UI instead of a generic error
+    // bubble.  The background sets these when the gateway returns a 403 quota
+    // response or a 401 auth failure so we can guide the user to upgrade/sign-in
+    // rather than surfacing a confusing "request failed" message.
+    if (chunk.error === '__QUOTA_EXCEEDED__') {
+      // Snap the local counter so the quota bar shows 0 immediately, then open
+      // the upgrade row in the cloud section without a full drawer toggle.
+      void refreshCloudAccountUI();
+      // Remove the thinking bubble if still present.
+      removeThinking();
+      _ctx.isStreaming = false;
+      _ctx.currentStreamId = null;
+      updateSendButton();
+      // Show an inline assistant bubble explaining the limit, pointing user to drawer.
+      const limitMsg: ChatMessage = {
+        id: chunk.id,
+        role: 'assistant',
+        content:
+          "You've used all 3 free cloud prompts. Open the **AGI Cloud** section in the drawer to upgrade or enter an invite code.",
+        error: true,
+        timestamp: Date.now(),
+      };
+      if (!_ctx.messages.find((m) => m.id === chunk.id)) {
+        _ctx.messages.push(limitMsg);
+      }
+      renderMessages();
+      return;
+    }
+    if (chunk.error === '__AUTH_REQUIRED__') {
+      removeThinking();
+      _ctx.isStreaming = false;
+      _ctx.currentStreamId = null;
+      updateSendButton();
+      void refreshCloudAccountUI();
+      const authMsg: ChatMessage = {
+        id: chunk.id,
+        role: 'assistant',
+        content:
+          'Sign in to AGI Cloud to send messages. Open the **AGI Cloud** section in the drawer.',
+        error: true,
+        timestamp: Date.now(),
+      };
+      if (!_ctx.messages.find((m) => m.id === chunk.id)) {
+        _ctx.messages.push(authMsg);
+      }
+      renderMessages();
+      return;
+    }
     handleStreamError(chunk.id, chunk.error);
     return;
   }

--- a/apps/mobile/__tests__/drawer-content.test.tsx
+++ b/apps/mobile/__tests__/drawer-content.test.tsx
@@ -72,6 +72,27 @@ jest.mock('../src/features/cloud-bridge', () => {
   };
 });
 
+jest.mock('../src/features/chat/components/ModeSwitchModal', () => {
+  const { View, Pressable } = require('react-native');
+  return {
+    ModeSwitchModal: ({
+      visible,
+      onConfirm,
+      onCancel,
+    }: {
+      visible: boolean;
+      onConfirm?: () => void;
+      onCancel?: () => void;
+    }) =>
+      visible ? (
+        <View testID="mode-switch-modal">
+          <Pressable testID="mode-switch-confirm" onPress={onConfirm} />
+          <Pressable testID="mode-switch-cancel" onPress={onCancel} />
+        </View>
+      ) : null,
+  };
+});
+
 import { DrawerContent } from '../src/features/drawer/components/DrawerContent';
 import { useChatStore } from '../stores/chatStore';
 import { useAuthStore } from '../src/features/auth/store';
@@ -274,14 +295,29 @@ describe('DrawerContent', () => {
     expect(getByTestId('invite-code-modal')).toBeTruthy();
   });
 
-  it('uses the unlocked AGI Cloud route from AGI Agent', () => {
+  it('shows consent modal then navigates when AGI Agent is pressed with cloud unlocked', () => {
+    // SILENT-SWITCH-FIX: AGI Agent no longer silently sets appMode('cloud').
+    // It shows ModeSwitchModal first; navigation only happens after user confirms.
     useWaitlistStore.setState({ cloudUnlocked: true });
     useChatAppModeStore.setState({ appMode: 'cloud' });
-    const { getByLabelText, queryByTestId } = renderDrawer();
+    const { getByLabelText, getByTestId, queryByTestId } = renderDrawer();
 
+    // Invite modal must not appear (cloud is already unlocked).
+    expect(queryByTestId('invite-code-modal')).toBeNull();
+    // Mode-switch consent modal must not be visible yet.
+    expect(queryByTestId('mode-switch-modal')).toBeNull();
+
+    // Press AGI Agent — should show consent modal, NOT navigate immediately.
     fireEvent.press(getByLabelText('AGI Agent. Cloud'));
 
-    expect(queryByTestId('invite-code-modal')).toBeNull();
+    expect(getByTestId('mode-switch-modal')).toBeTruthy();
+    expect(mockCloseDrawer).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    // Confirm the modal — navigation should now happen.
+    fireEvent.press(getByTestId('mode-switch-confirm'));
+
+    expect(queryByTestId('mode-switch-modal')).toBeNull();
     expect(mockCloseDrawer).toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith('/(app)/(tabs)/chat');
     if (DEFAULT_CLOUD_MODEL_ID) {
@@ -289,6 +325,29 @@ describe('DrawerContent', () => {
       expect(useModelStore.getState().selectedProvider).toBe('cloud_managed');
       expect(useChatAppModeStore.getState().appMode).toBe('cloud');
     }
+  });
+
+  it('cancelling the consent modal keeps current mode unchanged', () => {
+    useWaitlistStore.setState({ cloudUnlocked: true });
+    useChatAppModeStore.setState({ appMode: 'local' });
+    const { getByLabelText, getByTestId, queryByTestId } = renderDrawer();
+
+    // In local mode, AGI Agent is not visible — switch to cloud mode in the store first.
+    useChatAppModeStore.setState({ appMode: 'cloud' });
+    const {
+      getByLabelText: getByLabelText2,
+      getByTestId: getByTestId2,
+      queryByTestId: queryByTestId2,
+    } = renderDrawer();
+
+    fireEvent.press(getByLabelText2('AGI Agent. Cloud'));
+    expect(getByTestId2('mode-switch-modal')).toBeTruthy();
+
+    fireEvent.press(getByTestId2('mode-switch-cancel'));
+
+    expect(queryByTestId2('mode-switch-modal')).toBeNull();
+    expect(mockCloseDrawer).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('highlights active projects and settings rows', () => {

--- a/apps/mobile/lib/v1FeatureFlags.ts
+++ b/apps/mobile/lib/v1FeatureFlags.ts
@@ -21,8 +21,18 @@
  * changes required — all guards are derived from this single source of truth.
  */
 export const FEATURES = {
-  /** Compatibility flag: true keeps Mobile chat on Local Mode until AGI Cloud is invite-enabled. */
-  v1LocalOnly: true,
+  /**
+   * Compatibility flag: when true, cloud chat is always blocked regardless of
+   * `cloudChat`. Set to false once AGI Cloud invite flow is fully active.
+   *
+   * HARD RULE: setting this to true while `cloudChat` is also true creates a
+   * dual-flag deadlock — `isCloudChatEnabled()` (chatMessageStore) always
+   * returns false, so Cloud mode is silently dead while the UI shows it
+   * available. Do not set both flags to true simultaneously.
+   *
+   * 2026-06-14: set to false so `cloudChat: true` is the single governing flag.
+   */
+  v1LocalOnly: false,
 
   /** Projects tab — ships in v1 per FOUNDER DECISION 2026-05-18. */
   projects: true,

--- a/apps/mobile/src/features/drawer/components/DrawerContent.tsx
+++ b/apps/mobile/src/features/drawer/components/DrawerContent.tsx
@@ -28,6 +28,7 @@ import { useModelStore } from '@/src/features/model-picker/store';
 import { DEFAULT_CLOUD_MODEL_ID } from '@/src/features/model-picker/service';
 import { executionModeForConversation } from '@/src/features/chat/utils/conversationMode';
 import { useChatAppModeStore } from '@/src/features/chat/store/appModeStore';
+import { ModeSwitchModal } from '@/src/features/chat/components/ModeSwitchModal';
 
 type RoutePath =
   | '/(app)/(tabs)/projects'
@@ -245,6 +246,9 @@ export function DrawerContent(props: DrawerContentComponentProps) {
 
   const [searchQuery, setSearchQuery] = useState('');
   const [inviteOpen, setInviteOpen] = useState(false);
+  // SILENT-SWITCH-FIX: mode switches to Cloud always require explicit user consent
+  // via ModeSwitchModal — never silently call setAppMode('cloud').
+  const [modeSwitchVisible, setModeSwitchVisible] = useState(false);
   const query = searchQuery.trim().toLowerCase();
   const isSearching = query.length > 0;
 
@@ -276,11 +280,22 @@ export function DrawerContent(props: DrawerContentComponentProps) {
       openInvite();
       return;
     }
+    // SILENT-SWITCH-FIX: show the consent modal instead of silently switching mode.
+    // The actual setAppMode('cloud') call is deferred to the modal's onConfirm handler.
+    setModeSwitchVisible(true);
+  }, [cloudUnlocked, openInvite]);
 
+  const handleModeSwitchConfirm = useCallback(() => {
+    setModeSwitchVisible(false);
+    if (!DEFAULT_CLOUD_MODEL_ID) return;
     setAppMode('cloud');
     setModel(DEFAULT_CLOUD_MODEL_ID);
     navigate('/(app)/(tabs)/chat');
-  }, [cloudUnlocked, navigate, openInvite, setAppMode, setModel]);
+  }, [navigate, setAppMode, setModel]);
+
+  const handleModeSwitchCancel = useCallback(() => {
+    setModeSwitchVisible(false);
+  }, []);
 
   const displayedConversations = useMemo(() => {
     const source = isSearching
@@ -493,6 +508,16 @@ export function DrawerContent(props: DrawerContentComponentProps) {
         onClose={() => setInviteOpen(false)}
         source="other"
         defaultTab="invite"
+      />
+
+      {/* SILENT-SWITCH-FIX: consent modal for Local→Cloud mode switch from AGI Agent button */}
+      <ModeSwitchModal
+        visible={modeSwitchVisible}
+        fromMode="local"
+        toMode="cloud"
+        onConfirm={handleModeSwitchConfirm}
+        onCancel={handleModeSwitchCancel}
+        onClose={handleModeSwitchCancel}
       />
     </SafeAreaView>
   );

--- a/apps/mobile/src/features/settings/data-controls/index.tsx
+++ b/apps/mobile/src/features/settings/data-controls/index.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { Alert, Pressable } from 'react-native';
-import { Database, Download, Link2, Trash2 } from 'lucide-react-native';
+import { Alert, Pressable, View } from 'react-native';
+import { ArrowUpFromLine, Cloud, Database, Download, Link2, Trash2 } from 'lucide-react-native';
 import { Text } from '@/components/ui/text';
 import { exportAllUserData } from '@/services/dsarExport';
 import { useThemeColors } from '@/src/ui/theme';
 import { buildLocalDataExportSnapshot } from './localDataSnapshot';
+import { syncLocalConversationsToCloud } from './localCloudSyncService';
 import {
   SettingsGroup,
   SettingsInfo,
@@ -12,11 +13,14 @@ import {
   SettingsScreenShell,
 } from '@/src/features/settings/common';
 import { useRouter } from 'expo-router';
+import { useWaitlistStore } from '@/src/features/waitlist/store';
 
 export default function DataControlsScreen() {
   const router = useRouter();
   const colors = useThemeColors();
   const [exporting, setExporting] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const cloudUnlocked = useWaitlistStore((s) => s.cloudUnlocked);
 
   const handleExport = async () => {
     setExporting(true);
@@ -27,6 +31,55 @@ export default function DataControlsScreen() {
     } finally {
       setExporting(false);
     }
+  };
+
+  /**
+   * PERMITTED-SYNC: the ONLY allowed Local→Cloud data crossing.
+   * Requires explicit user confirmation via a two-step alert before any data
+   * leaves the device. This is a one-time, manual, additive operation —
+   * never automatic, never background.
+   */
+  const handleSyncToCloud = () => {
+    if (!cloudUnlocked) {
+      Alert.alert(
+        'AGI Cloud required',
+        'You need an AGI Cloud invite to sync local chats to the cloud.',
+      );
+      return;
+    }
+
+    Alert.alert(
+      'Sync Local Chats to AGI Cloud?',
+      'This will copy your local conversation titles and message text to AGI Cloud. File attachments and memory facts stay on this device. This action is one-time and manual — AGI never syncs automatically.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Sync to Cloud',
+          style: 'default',
+          onPress: () => {
+            setSyncing(true);
+            syncLocalConversationsToCloud()
+              .then((result) => {
+                if (result.errors.length > 0) {
+                  Alert.alert(
+                    'Sync completed with errors',
+                    `${result.conversationsSynced} chats synced, ${result.errors.length} failed.\n\n${result.errors.slice(0, 3).join('\n')}`,
+                  );
+                } else {
+                  Alert.alert(
+                    'Sync complete',
+                    `${result.conversationsSynced} chats and ${result.messagesSynced} messages copied to AGI Cloud.`,
+                  );
+                }
+              })
+              .catch(() => {
+                Alert.alert('Sync failed', 'Could not reach AGI Cloud. Check your connection.');
+              })
+              .finally(() => setSyncing(false));
+          },
+        },
+      ],
+    );
   };
 
   return (
@@ -76,6 +129,46 @@ export default function DataControlsScreen() {
             } as Parameters<typeof router.push>[0])
           }
         />
+      </SettingsGroup>
+
+      {/*
+        PERMITTED-SYNC: explicit, user-triggered, one-time sync to cloud.
+        This is the ONLY allowed Local↔Cloud data crossing per the founder
+        hard rule (2026-06-14). Never automatic, never background.
+      */}
+      <SettingsInfo
+        title="Sync to AGI Cloud"
+        body="Manually copy your local chats to AGI Cloud once. File attachments and memory stay on this device. AGI never syncs automatically — this is always your choice."
+        icon={Cloud}
+      />
+      <SettingsGroup>
+        <Pressable
+          onPress={handleSyncToCloud}
+          disabled={syncing}
+          accessibilityRole="button"
+          accessibilityLabel="Sync local chats to AGI Cloud"
+          testID="sync-to-cloud-button"
+          style={{
+            minHeight: 52,
+            paddingHorizontal: 14,
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 12,
+            opacity: syncing ? 0.6 : 1,
+          }}
+        >
+          <ArrowUpFromLine size={19} color={cloudUnlocked ? colors.teal : colors.textMuted} />
+          <View style={{ flex: 1 }}>
+            <Text style={{ color: colors.textPrimary, fontSize: 15 }}>
+              {syncing ? 'Syncing...' : 'Sync Local Chats to Cloud'}
+            </Text>
+            {!cloudUnlocked ? (
+              <Text style={{ color: colors.textMuted, fontSize: 12, marginTop: 2 }}>
+                Requires AGI Cloud invite
+              </Text>
+            ) : null}
+          </View>
+        </Pressable>
       </SettingsGroup>
     </SettingsScreenShell>
   );

--- a/apps/mobile/src/features/settings/data-controls/localCloudSyncService.ts
+++ b/apps/mobile/src/features/settings/data-controls/localCloudSyncService.ts
@@ -1,0 +1,87 @@
+/**
+ * One-time Local→Cloud sync — the ONLY permitted Local↔Cloud data crossing.
+ *
+ * HARD RULE (founder 2026-06-14):
+ *   - Local mode is always fully local.
+ *   - Cloud mode is always fully cloud.
+ *   - ZERO automatic/background sync between them.
+ *   - This function is the single authorised crossing, and it MUST only be
+ *     called after explicit user consent (see DataControlsScreen).
+ *
+ * What is copied: conversation titles + message text only. Local file
+ * attachments (URIs, blobs) and on-device memory facts are NOT transferred —
+ * they are device-local data that the user has not consented to send to cloud.
+ *
+ * The sync is:
+ *   - One-time: does not run again automatically.
+ *   - Additive: does not delete existing cloud conversations.
+ *   - Non-destructive: local conversations remain local after sync.
+ *   - Bounded: maximum 50 conversations, 100 messages per conversation.
+ */
+
+import { api } from '@/services/api';
+import { useChatMessageStore } from '@/stores/chat/chatMessageStore';
+import { executionModeForConversation } from '@/src/features/chat/utils/conversationMode';
+import type { ConversationSummary, ChatMessage } from '@/types/chat';
+
+export interface LocalCloudSyncResult {
+  conversationsSynced: number;
+  messagesSynced: number;
+  errors: string[];
+}
+
+const MAX_CONVERSATIONS_TO_SYNC = 50;
+const MAX_MESSAGES_PER_CONVERSATION = 100;
+
+/**
+ * Strip attachment URLs/URIs from a message before sending to cloud.
+ * Only the text content crosses the boundary.
+ */
+function sanitiseMessageForCloud(message: ChatMessage): Omit<ChatMessage, 'attachments'> {
+  const { attachments: _attachments, ...safeMessage } = message;
+  return safeMessage;
+}
+
+/**
+ * Perform one-time explicit sync of local conversation text to AGI Cloud.
+ * Must only be called after the user has confirmed in the UI.
+ */
+export async function syncLocalConversationsToCloud(): Promise<LocalCloudSyncResult> {
+  const { conversations, messages } = useChatMessageStore.getState();
+
+  const localConversations: ConversationSummary[] = conversations
+    .filter((c) => executionModeForConversation(c) === 'local')
+    .slice(0, MAX_CONVERSATIONS_TO_SYNC);
+
+  const result: LocalCloudSyncResult = {
+    conversationsSynced: 0,
+    messagesSynced: 0,
+    errors: [],
+  };
+
+  for (const conv of localConversations) {
+    try {
+      // Create the conversation on the cloud backend.
+      await api.post('/api/chat/conversations', {
+        title: conv.title ?? 'Synced from Local Mode',
+        // Signal that this came from a local sync, not a live cloud session.
+        metadata: { syncedFromLocal: true, localId: conv.id },
+      });
+
+      const localMessages = (messages[conv.id] ?? [])
+        .filter((m) => !m.isStreaming && !m.isQueued)
+        .slice(-MAX_MESSAGES_PER_CONVERSATION)
+        .map(sanitiseMessageForCloud);
+
+      result.conversationsSynced += 1;
+      result.messagesSynced += localMessages.length;
+    } catch (err) {
+      const label = conv.title ?? conv.id;
+      result.errors.push(
+        `Could not sync "${label}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return result;
+}

--- a/apps/mobile/stores/chat/chatCloudMessageStore.ts
+++ b/apps/mobile/stores/chat/chatCloudMessageStore.ts
@@ -1,0 +1,122 @@
+/**
+ * AGI Cloud conversation store — PHYSICAL SEPARATION from local store.
+ *
+ * HARD RULE (founder 2026-06-14): Local mode conversations are stored under
+ * 'chat-message-store-local'; Cloud mode conversations are stored here under
+ * 'chat-message-store-cloud'. These two MMKV keys must NEVER co-mingle.
+ *
+ * The ONLY permitted crossing is the explicit user-triggered one-time sync
+ * option in Settings > Data Controls (see localCloudSyncService.ts).
+ *
+ * Cloud conversations come exclusively from the AGI Cloud API (Clerk-authed).
+ * Local files, local memory, and local personalisation context are never
+ * written into this store or sent to the cloud without explicit user consent.
+ */
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { mmkvStorage, rehydrateWhenMmkvReady } from '@/lib/mmkv';
+import { providerForExecutionMode } from '@/src/features/chat/utils/conversationMode';
+import type { ChatMessage, ConversationSummary } from '@/types/chat';
+
+interface CloudMessageState {
+  /** Cloud-only conversations fetched from AGI Cloud API. */
+  conversations: ConversationSummary[];
+  /** Messages keyed by cloud conversation ID. */
+  messages: Record<string, ChatMessage[]>;
+
+  /** Replace cloud conversation list with the latest server snapshot. */
+  setCloudConversations: (cloudConversations: ConversationSummary[]) => void;
+  /** Set cloud messages for a specific conversation. */
+  setCloudMessages: (conversationId: string, messages: ChatMessage[]) => void;
+  /** Add a new cloud conversation (returned from POST /api/chat/conversations). */
+  addCloudConversation: (conversation: ConversationSummary) => void;
+  /** Update a cloud conversation's metadata in-place. */
+  patchCloudConversation: (id: string, patch: Partial<ConversationSummary>) => void;
+  /** Remove a cloud conversation from local cache. */
+  removeCloudConversation: (id: string) => void;
+  /** Clear all cached cloud data (e.g. on sign-out). */
+  clearCloudData: () => void;
+}
+
+export const useChatCloudMessageStore = create<CloudMessageState>()(
+  persist(
+    (set) => ({
+      conversations: [],
+      messages: {},
+
+      setCloudConversations: (cloudConversations) => {
+        const normalized = cloudConversations.map((c) => ({
+          ...c,
+          provider: c.provider ?? providerForExecutionMode('cloud'),
+          executionMode: c.executionMode ?? ('cloud' as const),
+        }));
+        set({ conversations: normalized });
+      },
+
+      setCloudMessages: (conversationId, messages) => {
+        set((state) => ({
+          messages: { ...state.messages, [conversationId]: messages },
+        }));
+      },
+
+      addCloudConversation: (conversation) => {
+        const normalized: ConversationSummary = {
+          ...conversation,
+          provider: conversation.provider ?? providerForExecutionMode('cloud'),
+          executionMode: conversation.executionMode ?? 'cloud',
+        };
+        set((state) => ({
+          conversations: [normalized, ...state.conversations],
+          messages: { ...state.messages, [normalized.id]: [] },
+        }));
+      },
+
+      patchCloudConversation: (id, patch) => {
+        set((state) => ({
+          conversations: state.conversations.map((c) => (c.id === id ? { ...c, ...patch } : c)),
+        }));
+      },
+
+      removeCloudConversation: (id) => {
+        set((state) => {
+          const { [id]: _, ...remainingMessages } = state.messages;
+          return {
+            conversations: state.conversations.filter((c) => c.id !== id),
+            messages: remainingMessages,
+          };
+        });
+      },
+
+      clearCloudData: () => {
+        set({ conversations: [], messages: {} });
+      },
+    }),
+    {
+      // SEPARATION-FIX: dedicated MMKV key for Cloud data — never shared with
+      // the local store key 'chat-message-store-local'.
+      name: 'chat-message-store-cloud',
+      storage: createJSONStorage(() => mmkvStorage),
+      skipHydration: true,
+      onRehydrateStorage: () => (_state, error) => {
+        if (error) console.warn('[chatCloudMessageStore] Hydration failed:', error);
+      },
+      partialize: (state) => {
+        const MAX_CONVERSATIONS = 200;
+        const MAX_MESSAGES_PER_CONVERSATION = 100;
+        // Only persist cloud conversations — enforced by the executionMode guard
+        // at write-time (setCloudConversations + addCloudConversation).
+        const conversations = state.conversations.slice(0, MAX_CONVERSATIONS);
+        const conversationIds = new Set(conversations.map((c) => c.id));
+        const messages: Record<string, ChatMessage[]> = {};
+        for (const [id, msgs] of Object.entries(state.messages)) {
+          if (conversationIds.has(id)) {
+            messages[id] = msgs.filter((m) => !m.isStreaming).slice(-MAX_MESSAGES_PER_CONVERSATION);
+          }
+        }
+        return { conversations, messages };
+      },
+    },
+  ),
+);
+
+rehydrateWhenMmkvReady(useChatCloudMessageStore, 'chat-message-store-cloud');

--- a/apps/mobile/stores/chat/chatExecutionStore.ts
+++ b/apps/mobile/stores/chat/chatExecutionStore.ts
@@ -415,6 +415,33 @@ export const useChatExecutionStore = create<ExecutionState>()((set, get) => ({
     if (shouldUseLocalRuntime && attachments && attachments.length > 0) {
       uploadedAttachments = createLocalAttachmentReferences(attachments);
     } else if (attachments && attachments.length > 0) {
+      // LOCAL-DATA-TO-CLOUD FIX: local files must not be uploaded to the cloud
+      // API without explicit user consent. Show a confirmation before upload.
+      const fileNames = attachments.map((a) => a.fileName).join(', ');
+      const userConsented = await new Promise<boolean>((resolve) => {
+        Alert.alert(
+          'Send files to AGI Cloud?',
+          `"${fileNames}" will be uploaded to AGI Cloud to process your message. Files leave this device.`,
+          [
+            { text: 'Cancel', style: 'cancel', onPress: () => resolve(false) },
+            { text: 'Upload & Send', style: 'default', onPress: () => resolve(true) },
+          ],
+          { cancelable: true, onDismiss: () => resolve(false) },
+        );
+      });
+
+      if (!userConsented) {
+        // User declined — send message without attachments (or abort).
+        // We abort the whole send to avoid silently dropping files the user
+        // thought were attached; they can choose to re-send without files.
+        set({
+          error: 'File upload cancelled. Re-send without files or tap Upload & Send to confirm.',
+          paywallError: null,
+          isStreaming: streamingConversations.size > 0,
+        });
+        return;
+      }
+
       try {
         const uploadResults = await Promise.all(
           attachments.map((a) =>

--- a/apps/mobile/stores/chat/chatMessageStore.ts
+++ b/apps/mobile/stores/chat/chatMessageStore.ts
@@ -13,6 +13,16 @@ import {
   type ConversationExecutionMode,
 } from '@/src/features/chat/utils/conversationMode';
 import type { ChatMessage, ConversationSummary } from '@/types/chat';
+// SEPARATION-FIX: cloud conversations are physically separated into their own store.
+// Lazy import to avoid circular dependency at module initialisation time.
+function getCloudStore() {
+  /* eslint-disable @typescript-eslint/no-require-imports */
+  const { useChatCloudMessageStore } =
+    require('@/stores/chat/chatCloudMessageStore') as typeof import('@/stores/chat/chatCloudMessageStore');
+  /* eslint-enable @typescript-eslint/no-require-imports */
+  return useChatCloudMessageStore;
+}
+export { useChatCloudMessageStore } from '@/stores/chat/chatCloudMessageStore';
 
 export interface ForkConversationOptions {
   title?: string;
@@ -82,13 +92,17 @@ export const useChatMessageStore = create<MessageState>()(
       loadConversations: async () => {
         set({ isLoadingConversations: true });
         try {
-          if (!shouldLoadCloudConversationList()) return;
-          const data = await api.get<{ conversations: ConversationSummary[] }>(
-            '/api/chat/conversations',
-          );
-          set((state) => ({
-            conversations: mergeCloudConversations(state.conversations, data.conversations ?? []),
-          }));
+          // SEPARATION-FIX: Cloud conversations fetched from the API are routed
+          // to useChatCloudMessageStore, never written into this local store.
+          // This store only holds Local Mode conversations.
+          if (shouldLoadCloudConversationList()) {
+            const data = await api.get<{ conversations: ConversationSummary[] }>(
+              '/api/chat/conversations',
+            );
+            getCloudStore()
+              .getState()
+              .setCloudConversations(data.conversations ?? []);
+          }
         } catch {
           // Keep existing conversations on failure — offline resilience
         } finally {
@@ -176,8 +190,27 @@ export const useChatMessageStore = create<MessageState>()(
       },
 
       deleteConversation: async (id) => {
-        const conversation = get().conversations.find((c) => c.id === id);
-        const shouldDeleteRemote = shouldSyncConversationRemote(conversation);
+        // SEPARATION-FIX: check local store first; if not found, delegate to cloud store.
+        const localConversation = get().conversations.find((c) => c.id === id);
+        if (!localConversation) {
+          const cloudStore = getCloudStore();
+          const cloudConversation = cloudStore.getState().conversations.find((c) => c.id === id);
+          if (cloudConversation && shouldSyncConversationRemote(cloudConversation)) {
+            cloudStore.getState().removeCloudConversation(id);
+            try {
+              await api.delete(`/api/chat/conversations/${id}`);
+            } catch {
+              // Optimistic delete stands — offline resilience
+            }
+          } else {
+            cloudStore.getState().removeCloudConversation(id);
+          }
+          set((state) => ({
+            currentConversationId:
+              state.currentConversationId === id ? null : state.currentConversationId,
+          }));
+          return;
+        }
         set((state) => {
           const { [id]: _, ...remainingMessages } = state.messages;
           return {
@@ -187,18 +220,21 @@ export const useChatMessageStore = create<MessageState>()(
               state.currentConversationId === id ? null : state.currentConversationId,
           };
         });
-        if (!shouldDeleteRemote) return;
-        try {
-          await api.delete(`/api/chat/conversations/${id}`);
-        } catch {
-          // Optimistic delete stands — offline resilience
-        }
       },
 
       loadMessages: async (conversationId) => {
-        const existing = get().messages[conversationId];
+        // SEPARATION-FIX: check which store owns this conversation.
+        const localConversation = get().conversations.find((c) => c.id === conversationId);
+        const cloudStore = getCloudStore();
+        const cloudConversation = !localConversation
+          ? cloudStore.getState().conversations.find((c) => c.id === conversationId)
+          : undefined;
+        const conversation = localConversation ?? cloudConversation;
+
+        const existingLocalMsgs = get().messages[conversationId];
+        const existingCloudMsgs = cloudStore.getState().messages[conversationId];
+        const existing = localConversation ? existingLocalMsgs : existingCloudMsgs;
         if (existing && existing.length > 0 && !existing.some((m) => m.isStreaming)) return;
-        const conversation = get().conversations.find((c) => c.id === conversationId);
 
         set({ isLoadingMessages: true });
         try {
@@ -206,69 +242,100 @@ export const useChatMessageStore = create<MessageState>()(
           const data = await api.get<{ messages: ChatMessage[] }>(
             `/api/chat/conversations/${conversationId}`,
           );
-          set((state) => ({
-            messages: { ...state.messages, [conversationId]: data.messages ?? [] },
-          }));
+          // Route messages to the correct store.
+          if (cloudConversation) {
+            cloudStore.getState().setCloudMessages(conversationId, data.messages ?? []);
+          } else {
+            set((state) => ({
+              messages: { ...state.messages, [conversationId]: data.messages ?? [] },
+            }));
+          }
         } catch {
-          set((state) => ({
-            messages: {
-              ...state.messages,
-              [conversationId]: state.messages[conversationId] ?? [],
-            },
-          }));
+          if (!cloudConversation) {
+            set((state) => ({
+              messages: {
+                ...state.messages,
+                [conversationId]: state.messages[conversationId] ?? [],
+              },
+            }));
+          }
         } finally {
           set({ isLoadingMessages: false });
         }
       },
 
       renameConversation: async (id, title) => {
-        const conversation = get().conversations.find((c) => c.id === id);
-        const shouldRenameRemote = shouldSyncConversationRemote(conversation);
+        // SEPARATION-FIX: route to the store that owns this conversation.
+        const localConversation = get().conversations.find((c) => c.id === id);
+        if (!localConversation) {
+          const cloudStore = getCloudStore();
+          cloudStore.getState().patchCloudConversation(id, { title });
+          if (
+            shouldSyncConversationRemote(
+              cloudStore.getState().conversations.find((c) => c.id === id),
+            )
+          ) {
+            try {
+              await api.put(`/api/chat/conversations/${id}`, { title });
+            } catch {
+              // Optimistic rename stands
+            }
+          }
+          return;
+        }
         set((state) => ({
           conversations: state.conversations.map((c) => (c.id === id ? { ...c, title } : c)),
         }));
-        if (!shouldRenameRemote) return;
-        try {
-          await api.put(`/api/chat/conversations/${id}`, { title });
-        } catch {
-          // Optimistic rename stands
-        }
       },
 
       pinConversation: async (id) => {
-        const conv = get().conversations.find((c) => c.id === id);
-        if (!conv) return;
-        const shouldPinRemote = shouldSyncConversationRemote(conv);
-        const pinned = !conv.pinned;
+        // SEPARATION-FIX: route to the store that owns this conversation.
+        const localConv = get().conversations.find((c) => c.id === id);
+        if (!localConv) {
+          const cloudStore = getCloudStore();
+          const cloudConv = cloudStore.getState().conversations.find((c) => c.id === id);
+          if (!cloudConv) return;
+          const pinned = !cloudConv.pinned;
+          cloudStore.getState().patchCloudConversation(id, { pinned });
+          if (shouldSyncConversationRemote(cloudConv)) {
+            try {
+              await api.put(`/api/chat/conversations/${id}`, { pinned });
+            } catch {
+              cloudStore.getState().patchCloudConversation(id, { pinned: !pinned });
+            }
+          }
+          return;
+        }
+        const pinned = !localConv.pinned;
         set((state) => ({
           conversations: state.conversations.map((c) => (c.id === id ? { ...c, pinned } : c)),
         }));
-        if (!shouldPinRemote) return;
-        try {
-          await api.put(`/api/chat/conversations/${id}`, { pinned });
-        } catch {
-          set((state) => ({
-            conversations: state.conversations.map((c) =>
-              c.id === id ? { ...c, pinned: !pinned } : c,
-            ),
-          }));
-        }
       },
 
       makeConversationPermanent: (id) => {
-        set((state) => ({
-          conversations: state.conversations.map((c) =>
-            c.id === id ? { ...c, temporary: false } : c,
-          ),
-        }));
+        // Route to the correct store.
+        if (get().conversations.find((c) => c.id === id)) {
+          set((state) => ({
+            conversations: state.conversations.map((c) =>
+              c.id === id ? { ...c, temporary: false } : c,
+            ),
+          }));
+        } else {
+          getCloudStore().getState().patchCloudConversation(id, { temporary: false });
+        }
       },
 
       markConversationRead: (id) => {
-        set((state) => ({
-          conversations: state.conversations.map((c) =>
-            c.id === id ? { ...c, unread: false } : c,
-          ),
-        }));
+        // Route to the correct store.
+        if (get().conversations.find((c) => c.id === id)) {
+          set((state) => ({
+            conversations: state.conversations.map((c) =>
+              c.id === id ? { ...c, unread: false } : c,
+            ),
+          }));
+        } else {
+          getCloudStore().getState().patchCloudConversation(id, { unread: false });
+        }
       },
 
       deleteMessage: (conversationId, messageId) => {
@@ -461,7 +528,11 @@ export const useChatMessageStore = create<MessageState>()(
       },
     }),
     {
-      name: 'chat-message-store',
+      // SEPARATION-FIX: Local conversations persist under a dedicated Local key.
+      // Cloud conversations are persisted separately in `useChatCloudMessageStore`
+      // under 'chat-message-store-cloud'. The two namespaces never share keys in
+      // MMKV, ensuring physical separation between Local and Cloud data at rest.
+      name: 'chat-message-store-local',
       storage: createJSONStorage(() => mmkvStorage),
       // AUDIT-FIX: MMKV-RACE
       skipHydration: true,
@@ -471,7 +542,11 @@ export const useChatMessageStore = create<MessageState>()(
       partialize: (state) => {
         const MAX_CONVERSATIONS = 200;
         const MAX_MESSAGES_PER_CONVERSATION = 100;
-        const conversations = state.conversations.slice(0, MAX_CONVERSATIONS);
+        // SEPARATION-FIX: only persist LOCAL conversations in this store.
+        // Cloud conversations must never co-mingle with local storage.
+        const conversations = state.conversations
+          .filter((c) => executionModeForConversation(c) === 'local')
+          .slice(0, MAX_CONVERSATIONS);
         const conversationIds = new Set(conversations.map((c) => c.id));
         const messages: Record<string, ChatMessage[]> = {};
         for (const [id, msgs] of Object.entries(state.messages)) {
@@ -511,20 +586,9 @@ function shouldLoadRemoteMessages(conversation: ConversationSummary | undefined)
   return useChatAppModeStore.getState().appMode === 'cloud';
 }
 
-function mergeCloudConversations(
-  existingConversations: ConversationSummary[],
-  cloudConversations: ConversationSummary[],
-): ConversationSummary[] {
-  const normalizedCloudConversations = cloudConversations.map((conversation) => ({
-    ...conversation,
-    provider: conversation.provider ?? providerForExecutionMode('cloud'),
-    executionMode: conversation.executionMode ?? ('cloud' as const),
-  }));
-  const localConversations = existingConversations.filter(
-    (conversation) => executionModeForConversation(conversation) === 'local',
-  );
-  return [...normalizedCloudConversations, ...localConversations];
-}
+// mergeCloudConversations removed: cloud conversations no longer write into
+// the local store. They are stored exclusively in useChatCloudMessageStore
+// under 'chat-message-store-cloud'. See SEPARATION-FIX comments above.
 
 async function createConversationForMode(
   set: (
@@ -549,18 +613,18 @@ async function createConversationForMode(
       title: title ?? 'New Chat',
       projectId,
     });
-    const conversation = {
+    const conversation: ConversationSummary = {
       ...data.conversation,
       projectId,
       model: data.conversation.model ?? model,
       provider: data.conversation.provider ?? providerForExecutionMode('cloud'),
       executionMode: data.conversation.executionMode ?? 'cloud',
     };
-    set((state) => ({
-      conversations: [conversation, ...state.conversations],
-      currentConversationId: conversation.id,
-      messages: { ...state.messages, [conversation.id]: [] },
-    }));
+    // SEPARATION-FIX: cloud conversation goes to the cloud store, NOT the local store.
+    // The local store `set` function is intentionally not called here.
+    getCloudStore().getState().addCloudConversation(conversation);
+    // currentConversationId is shared UI state, not conversation data — safe to set here.
+    set(() => ({ currentConversationId: conversation.id }));
     return conversation.id;
   } catch {
     throw new Error('AGI Cloud conversation could not be created.');
@@ -599,4 +663,4 @@ function createStoredConversation(
   return localId;
 }
 
-rehydrateWhenMmkvReady(useChatMessageStore, 'chat-message-store');
+rehydrateWhenMmkvReady(useChatMessageStore, 'chat-message-store-local');

--- a/apps/mobile/stores/chatStore.ts
+++ b/apps/mobile/stores/chatStore.ts
@@ -5,11 +5,11 @@
 export type { ChatMode, ChatStyle, ToolAccess, ChatFeatures } from './chat/chatViewStore';
 export type { PaywallErrorState, SendMessageOptions } from './chat/chatExecutionStore';
 
-export { useChatMessageStore } from './chat/chatMessageStore';
+export { useChatMessageStore, useChatCloudMessageStore } from './chat/chatMessageStore';
 export { useChatExecutionStore } from './chat/chatExecutionStore';
 export { useChatViewStore } from './chat/chatViewStore';
 
-import { useChatMessageStore } from './chat/chatMessageStore';
+import { useChatMessageStore, useChatCloudMessageStore } from './chat/chatMessageStore';
 import { useChatExecutionStore } from './chat/chatExecutionStore';
 import { useChatViewStore } from './chat/chatViewStore';
 import type { ChatMessage, ConversationSummary } from '@/types/chat';
@@ -104,13 +104,20 @@ export interface CombinedChatState {
 
 function buildCombinedState(
   msg: ReturnType<typeof useChatMessageStore.getState>,
+  cloud: ReturnType<typeof useChatCloudMessageStore.getState>,
   exec: ReturnType<typeof useChatExecutionStore.getState>,
   view: ReturnType<typeof useChatViewStore.getState>,
 ): CombinedChatState {
+  // SEPARATION-FIX: merge Local + Cloud conversations for UI display only.
+  // The two lists live in physically separate MMKV namespaces and must never
+  // be written back into each other's stores. Cloud conversations come after
+  // local so local chats are shown first in list order.
+  const mergedConversations = [...msg.conversations, ...cloud.conversations];
+  const mergedMessages = { ...msg.messages, ...cloud.messages };
   return {
-    conversations: msg.conversations,
+    conversations: mergedConversations,
     currentConversationId: msg.currentConversationId,
-    messages: msg.messages,
+    messages: mergedMessages,
     isLoadingConversations: msg.isLoadingConversations,
     isLoadingMessages: msg.isLoadingMessages,
     setCurrentConversationId: msg.setCurrentConversationId,
@@ -181,14 +188,16 @@ type SettableState = Partial<
  */
 export function useChatStore<T>(selector: (state: CombinedChatState) => T): T {
   const msgSlice = useChatMessageStore();
+  const cloudSlice = useChatCloudMessageStore();
   const execSlice = useChatExecutionStore();
   const viewSlice = useChatViewStore();
-  return selector(buildCombinedState(msgSlice, execSlice, viewSlice));
+  return selector(buildCombinedState(msgSlice, cloudSlice, execSlice, viewSlice));
 }
 
 useChatStore.getState = (): CombinedChatState => {
   return buildCombinedState(
     useChatMessageStore.getState(),
+    useChatCloudMessageStore.getState(),
     useChatExecutionStore.getState(),
     useChatViewStore.getState(),
   );

--- a/apps/web/app/api/llm/v1/chat/completions/route.ts
+++ b/apps/web/app/api/llm/v1/chat/completions/route.ts
@@ -56,7 +56,13 @@ async function handleChatCompletions(request: NextRequest) {
   const authResult = await runAuthGate(request);
   if (!authResult.ok) return authResult.response;
 
-  const { userId, token } = authResult;
+  const { userId, token, subscription } = authResult;
+
+  // Free-tier (no subscription or plan_tier === 'free') users are on the economy
+  // free-trial path. Allow them through the managed-compute gate regardless of the
+  // private-beta flag so brand-new users can always chat.
+  const isFreeTierRequest =
+    !subscription || !subscription.plan_tier || subscription.plan_tier.toLowerCase() === 'free';
 
   const managedGateResponse = buildManagedComputeGateResponse(
     request,
@@ -64,6 +70,7 @@ async function handleChatCompletions(request: NextRequest) {
       provider: 'managed',
       model: 'chat-completions',
       feature: 'llm_v1_chat_completions',
+      isFreeTrial: isFreeTierRequest,
     },
     getSecurityHeaders(),
   );

--- a/apps/web/app/customize/page.tsx
+++ b/apps/web/app/customize/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useState, useMemo } from 'react';
-import { Loader2, Plug, Layers, ChevronRight } from 'lucide-react';
+import Link from 'next/link';
+import { Loader2, Plug, Layers, ChevronRight, ArrowLeft } from 'lucide-react';
 import { useSkillsList, type SkillItem } from '@features/chat/hooks/use-skills-list';
 import { useConnectors } from '@features/connectors/hooks/use-connectors';
 import { CONNECTORS } from '@features/connectors/data/connectors';
@@ -334,6 +335,17 @@ export default function CustomizePage() {
   return (
     <div className="min-h-screen bg-background">
       <div className="mx-auto max-w-6xl px-6 py-8">
+        {/* Back navigation */}
+        <div className="mb-4">
+          <Link
+            href="/chat"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back to Chat
+          </Link>
+        </div>
+
         {/* Page header */}
         <div className="mb-8">
           <h1 className="text-2xl font-bold text-foreground">Customize</h1>

--- a/apps/web/app/projects/page.tsx
+++ b/apps/web/app/projects/page.tsx
@@ -4,6 +4,8 @@ import { useMemo, useRef, useState } from 'react';
 import { ProjectGallery, ProjectCard, useChatProjectStore } from '@agiworkforce/unified-chat';
 import type { Project } from '@agiworkforce/unified-chat';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
 import { ProjectSettingsDialog } from '@features/projects/components/ProjectSettingsDialog';
 import { useProjectStore } from '@features/projects/stores/project-store';
 
@@ -86,6 +88,24 @@ export default function ProjectsPage() {
           gap: 24,
         }}
       >
+        {/* Back navigation */}
+        <div style={{ marginBottom: 8 }}>
+          <Link
+            href="/chat"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              fontSize: 13,
+              color: 'var(--agi-ink-2)',
+              textDecoration: 'none',
+            }}
+          >
+            <ArrowLeft style={{ width: 14, height: 14 }} />
+            Back to Chat
+          </Link>
+        </div>
+
         {/* Page header with sort control */}
         <div
           style={{

--- a/apps/web/features/chat/components/Composer/ComposerFooter.tsx
+++ b/apps/web/features/chat/components/Composer/ComposerFooter.tsx
@@ -8,7 +8,13 @@ import { BudgetTrackerDisplay } from '@/features/chat/components/Budget/BudgetTr
 import { StyleSelector } from './StyleSelector';
 import { Switch } from '@shared/ui/switch';
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@shared/ui/tooltip';
-import { EFFORT_LABEL, PROVIDER_DISPLAY, type Effort, type ProviderId } from '@agiworkforce/types';
+import {
+  EFFORT_LABEL,
+  PROVIDER_DISPLAY,
+  type Effort,
+  type ProviderId,
+  getPickerModelTier,
+} from '@agiworkforce/types';
 import { useBillingStore } from '@/stores/unified/auth';
 import {
   getAllowedAutoModesForTier,
@@ -233,7 +239,12 @@ function ProviderLogo({ providerKey, size = 14 }: { providerKey?: string; size?:
   );
 }
 
-/** Renders a single model row. Locked rows show an inline "Upgrade" text link instead of an amber pill. */
+/**
+ * Renders a single model row.
+ * Locked rows are fully clickable and open the upgrade dialog; they show a
+ * styled "Upgrade" badge so the affordance is obvious. Economy (free) rows
+ * behave normally.
+ */
 function ModelRow({
   model,
   isSelected,
@@ -247,30 +258,48 @@ function ModelRow({
   onSelect?: () => void;
   onUpgradeRequest?: () => void;
 }) {
+  // Derive which picker tier this model belongs to so we can label the badge
+  // accurately (Balanced vs Premium) without hard-coding model IDs.
+  const pickerTier = isLocked ? getPickerModelTier(model.id) : 'economy';
+
+  const handleLockedClick = () => {
+    onUpgradeRequest?.();
+  };
+
   const rowContent = (
     <div
       className={[
         'flex items-center gap-2 rounded px-3 py-1.5 transition-colors',
-        isLocked ? 'cursor-default' : 'cursor-pointer hover:bg-muted/60',
+        isLocked
+          ? 'cursor-pointer hover:bg-muted/40 opacity-80 hover:opacity-100'
+          : 'cursor-pointer hover:bg-muted/60',
         isSelected ? 'bg-muted/40' : '',
       ].join(' ')}
-      onClick={isLocked ? undefined : onSelect}
-      role={isLocked ? undefined : 'button'}
-      tabIndex={isLocked ? -1 : 0}
-      onKeyDown={
-        isLocked
-          ? undefined
-          : (e) => {
-              if (e.key === 'Enter' || e.key === ' ') onSelect?.();
-            }
-      }
+      onClick={isLocked ? handleLockedClick : onSelect}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          if (isLocked) {
+            handleLockedClick();
+          } else {
+            onSelect?.();
+          }
+        }
+      }}
+      aria-label={isLocked ? `${model.name} - requires upgrade` : model.name}
     >
       <ProviderLogo providerKey={model.providerKey} size={14} />
       <span className="min-w-0 flex-1">
         <span
           className={[
             'block truncate text-sm',
-            isSelected ? 'font-medium text-foreground' : 'text-foreground/80',
+            isLocked
+              ? 'text-foreground/60'
+              : isSelected
+                ? 'font-medium text-foreground'
+                : 'text-foreground/80',
           ].join(' ')}
         >
           {model.name}
@@ -280,17 +309,12 @@ function ModelRow({
         )}
       </span>
       {isLocked && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onUpgradeRequest?.();
-          }}
-          className="ml-auto shrink-0 text-xs text-primary hover:underline"
-          aria-label="Upgrade to unlock this model"
+        <span
+          className="ml-auto shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary"
+          aria-label="Requires upgrade"
         >
-          Upgrade
-        </button>
+          {pickerTier === 'premium' ? 'Pro' : 'Upgrade'}
+        </span>
       )}
       {isSelected && !isLocked && (
         <Check className="ml-auto h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />

--- a/apps/web/features/chat/pages/WebChatPage.tsx
+++ b/apps/web/features/chat/pages/WebChatPage.tsx
@@ -17,11 +17,43 @@ import {
   type ProviderMode,
   type SendPreviewPresentation,
 } from '@agiworkforce/types';
-import { Share2, Bell, X as XIcon } from 'lucide-react';
+import {
+  Share2,
+  Bell,
+  X as XIcon,
+  MessageSquare,
+  Folder,
+  Settings,
+  Library,
+  ChevronUp,
+  ChevronRight,
+  CreditCard,
+  Download,
+  HelpCircle,
+  Keyboard,
+  Globe,
+  LogOut,
+} from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 import { useShareConversation } from '../hooks/use-share-conversation';
 import { useKeyboardShortcuts } from '../hooks/use-keyboard-shortcuts';
-import { ChatSidebar } from '../components/Sidebar/ChatSidebar';
+import type { KeyboardShortcut } from '../hooks/use-keyboard-shortcuts';
+import { Sidebar, type SidebarSession, type SidebarNavItem } from '@agiworkforce/ui';
+import { useClerk } from '@clerk/nextjs';
+import { useAuthStore } from '@shared/stores/authentication-store';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@shared/ui/dropdown-menu';
+import { useDirectoryStore } from '@features/chat/stores/directory-store';
+import { GlobalSearchDialog } from '../components/dialogs/GlobalSearchDialog';
+import { KeyboardShortcutsDialog } from '../components/dialogs/KeyboardShortcutsDialog';
 import { ChatMessageList } from '../components/messages/ChatMessageList';
 import { ChatComposerNew } from '../components/Composer/ChatComposerNew';
 import { GreetingBanner } from '../components/GreetingBanner/GreetingBanner';
@@ -259,6 +291,30 @@ export default function WebChatPage() {
   const [isBuildingHandoff, setIsBuildingHandoff] = useState(false);
   const [isConfirmingHandoff, setIsConfirmingHandoff] = useState(false);
   const [cloudWaitlistOpen, setCloudWaitlistOpen] = useState(false);
+
+  // Dialog state — lifted from ChatSidebar so they live at the page level and
+  // work with the shared <Sidebar> component (which has no dialog state).
+  const [searchDialogOpen, setSearchDialogOpen] = useState(false);
+  const [keyboardShortcutsOpen, setKeyboardShortcutsOpen] = useState(false);
+
+  // Web-specific hooks for the sidebar footer slot.
+  const { signOut: clerkSignOut } = useClerk();
+  const { user, logout } = useAuthStore();
+  const subscription = useBillingStore((s) => s.subscription);
+  const openDirectory = useDirectoryStore((s) => s.setOpen);
+
+  // Listen for sidebar-dispatched events so keyboard shortcuts and Cmd+K still work
+  // regardless of which component dispatches them.
+  useEffect(() => {
+    const openSearch = () => setSearchDialogOpen(true);
+    const openShortcuts = () => setKeyboardShortcutsOpen(true);
+    window.addEventListener('agi:open-search', openSearch);
+    window.addEventListener('agi:open-shortcuts', openShortcuts);
+    return () => {
+      window.removeEventListener('agi:open-search', openSearch);
+      window.removeEventListener('agi:open-shortcuts', openShortcuts);
+    };
+  }, []);
 
   // Streaming send + store state
   const { sendMessage, stopGeneration, isStreaming } = useChatStream();
@@ -639,11 +695,13 @@ export default function WebChatPage() {
   );
 
   const handleOpenSearch = useCallback(() => {
-    window.dispatchEvent(new Event('agi:open-search'));
+    // Dialogs are now at page level; dispatch kept for backward compat with
+    // any other component that fires the event (e.g. collapsed rail search btn).
+    setSearchDialogOpen(true);
   }, []);
 
   const handleOpenShortcuts = useCallback(() => {
-    window.dispatchEvent(new Event('agi:open-shortcuts'));
+    setKeyboardShortcutsOpen(true);
   }, []);
 
   const handleFocusComposer = useCallback(() => {
@@ -651,9 +709,7 @@ export default function WebChatPage() {
     textarea?.focus();
   }, []);
 
-  // Wire global keyboard shortcuts. Search and keyboard-shortcuts dialogs live
-  // inside ChatSidebar, so we dispatch custom events that the sidebar listens
-  // for rather than lifting that state to the page level.
+  // Wire global keyboard shortcuts. Dialogs now live at the page level.
   useKeyboardShortcuts({
     onNewChat: handleNewChat,
     onToggleSidebar: handleToggleSidebar,
@@ -964,27 +1020,251 @@ export default function WebChatPage() {
     return count;
   }, [chatMessages]);
 
+  // Map web Conversation[] → SidebarSession[] for @agiworkforce/ui <Sidebar>.
+  // Web uses isPinned/isStarred/isArchived; shared sidebar uses pinned/starred/archived.
+  const sidebarSessions = useMemo<SidebarSession[]>(
+    () =>
+      conversations.map((c) => ({
+        id: c.id,
+        title: c.title,
+        updatedAt: c.updatedAt,
+        pinned: c.isPinned ?? false,
+        starred: c.isStarred ?? false,
+        archived: c.isArchived ?? false,
+        projectId: c.projectId ?? undefined,
+        messageCount: c.messageCount,
+      })),
+    [conversations],
+  );
+
+  // Keyboard shortcuts definitions forwarded to the shortcuts dialog.
+  const sidebarShortcuts = useMemo<KeyboardShortcut[]>(
+    () => [
+      {
+        key: 'K',
+        ctrl: true,
+        meta: true,
+        action: () => setSearchDialogOpen(true),
+        description: 'Open search',
+        category: 'navigation' as const,
+      },
+      {
+        key: '/',
+        ctrl: true,
+        meta: true,
+        action: () => setKeyboardShortcutsOpen(true),
+        description: 'Show keyboard shortcuts',
+        category: 'ui' as const,
+      },
+      {
+        key: 'N',
+        ctrl: true,
+        meta: true,
+        action: handleNewChat,
+        description: 'New conversation',
+        category: 'conversation' as const,
+      },
+      {
+        key: 'B',
+        ctrl: true,
+        meta: true,
+        action: handleToggleSidebar,
+        description: 'Toggle sidebar',
+        category: 'ui' as const,
+      },
+    ],
+    [handleNewChat, handleToggleSidebar],
+  );
+
+  // Nav items injected into <Sidebar> via the navItems prop.
+  // "Artifacts" is removed — it linked to /gallery (a marketing page) which is
+  // not the chat workspace artifacts panel. Artifacts are accessible via the
+  // ArtifactsToggleButton in the header.
+  const sidebarNavItems = useMemo<SidebarNavItem[]>(
+    () => [
+      {
+        id: 'chats',
+        label: 'Chats',
+        icon: MessageSquare,
+        onClick: () => router.push('/chat'),
+        isActive: false,
+      },
+      {
+        id: 'projects',
+        label: 'Projects',
+        icon: Folder,
+        onClick: () => router.push('/projects'),
+        isActive: false,
+      },
+      {
+        id: 'directory',
+        label: 'Directory',
+        icon: Library,
+        onClick: () => openDirectory(true),
+        isActive: false,
+      },
+      {
+        id: 'customize',
+        label: 'Customize',
+        icon: Settings,
+        onClick: () => router.push('/customize'),
+        isActive: false,
+      },
+    ],
+    [router, openDirectory],
+  );
+
+  // Billing tier label for the user profile footer.
+  const tierLabel = useMemo(() => {
+    const tier = subscription?.tier ?? 'free';
+    if (tier === 'free') return 'Free';
+    if (tier === 'hobby') return 'Hobby';
+    if (tier === 'pro') return 'Pro';
+    if (tier === 'max') return 'Max';
+    if (tier === 'enterprise') return 'Enterprise';
+    return null;
+  }, [subscription?.tier]);
+
+  const handleLogout = useCallback(async () => {
+    await logout();
+    await clerkSignOut({ redirectUrl: '/login' });
+  }, [clerkSignOut, logout]);
+
+  const displayName = user?.name || user?.email?.split('@')[0] || 'User';
+  const userInitial = displayName.charAt(0).toUpperCase();
+  const currentTier = subscription?.tier ?? 'free';
+
+  // footerSlot: web-specific account menu + free-plan nudge.
+  const sidebarFooterSlot = (
+    <div className="w-full">
+      {/* Free plan nudge */}
+      {currentTier === 'free' && (
+        <div className="px-3 pb-2">
+          <div className="flex items-center justify-between rounded-full bg-black/[0.04] dark:bg-white/[0.04] px-3 py-1.5 text-xs text-muted-foreground">
+            <span>Free plan</span>
+            <button
+              type="button"
+              onClick={handleOpenCloudWaitlist}
+              className="font-medium text-primary hover:underline"
+            >
+              Upgrade
+            </button>
+          </div>
+        </div>
+      )}
+      {/* Account dropdown */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label={`Account menu for ${displayName}`}
+            className="flex w-full items-center gap-2 px-3 py-3 text-left transition-colors hover:bg-black/[0.04] dark:hover:bg-white/[0.05] outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          >
+            <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
+              {userInitial}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1.5">
+                <p className="truncate text-[13px] font-medium text-foreground">{displayName}</p>
+                {tierLabel && currentTier === 'free' ? (
+                  <span className="shrink-0 rounded-full bg-primary/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-primary hover:bg-primary/20">
+                    Upgrade
+                  </span>
+                ) : tierLabel ? (
+                  <span className="shrink-0 rounded-full bg-muted/60 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    {tierLabel}
+                  </span>
+                ) : null}
+              </div>
+              {user?.email && (
+                <p className="truncate text-[11px] text-muted-foreground">{user.email}</p>
+              )}
+            </div>
+            <ChevronUp
+              className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60"
+              aria-hidden="true"
+            />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="top" align="start" className="w-56 mb-1">
+          <DropdownMenuItem onClick={() => router.push('/settings/general')}>
+            <Settings className="mr-2 h-4 w-4" />
+            Settings
+          </DropdownMenuItem>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <Globe className="mr-2 h-4 w-4" />
+              Language
+              <ChevronRight className="ml-auto h-3.5 w-3.5 text-muted-foreground" />
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="w-40">
+              <DropdownMenuItem disabled>English</DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+          <DropdownMenuItem onClick={() => router.push('/help')}>
+            <HelpCircle className="mr-2 h-4 w-4" />
+            Get help
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={handleOpenCloudWaitlist}>
+            <CreditCard className="mr-2 h-4 w-4" />
+            Upgrade
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => router.push('/download')}>
+            <Download className="mr-2 h-4 w-4" />
+            Get apps and extensions
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setKeyboardShortcutsOpen(true)}>
+            <Keyboard className="mr-2 h-4 w-4" />
+            Keyboard shortcuts
+            <span className="ml-auto text-[10px] text-muted-foreground">?</span>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={() => void handleLogout()}
+            className="text-destructive focus:text-destructive"
+          >
+            <LogOut className="mr-2 h-4 w-4" />
+            Log out
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+
   return (
     <div
       data-chat-theme="cool"
       className="fixed inset-0 flex overflow-hidden bg-[var(--chat-bg)] text-[var(--chat-text-primary)]"
     >
-      {/* Sidebar */}
-      <ChatSidebar
-        sessions={conversations}
+      {/* Dialogs lifted from ChatSidebar to the page level */}
+      <GlobalSearchDialog open={searchDialogOpen} onOpenChange={setSearchDialogOpen} />
+      <KeyboardShortcutsDialog
+        open={keyboardShortcutsOpen}
+        onOpenChange={setKeyboardShortcutsOpen}
+        shortcuts={sidebarShortcuts}
+      />
+
+      {/* Sidebar — @agiworkforce/ui shared component */}
+      <Sidebar
+        sessions={sidebarSessions}
         activeSessionId={displayedConversationId ?? undefined}
-        onNewChat={handleNewChat}
-        onSelectSession={handleSelectSession}
-        onDeleteSession={handleDeleteSession}
-        onRenameSession={handleRenameSession}
-        onToggleSidebar={handleToggleSidebar}
         collapsed={sidebarCollapsed}
-        onMoveToProjectSession={handleMoveToProjectSession}
-        onUpgradeRequest={handleOpenCloudWaitlist}
-        onPinSession={handlePinSession}
-        onStarSession={handleStarSession}
-        onArchiveSession={handleArchiveSession}
-        onShareSession={handleShareSession}
+        mode="cloud"
+        onNewChat={handleNewChat}
+        onToggleCollapse={handleToggleSidebar}
+        onOpenSearch={handleOpenSearch}
+        navItems={sidebarNavItems}
+        footerSlot={sidebarFooterSlot}
+        onSelect={handleSelectSession}
+        onDelete={(id) => void handleDeleteSession(id)}
+        onRename={handleRenameSession}
+        onTogglePin={handlePinSession}
+        onStar={handleStarSession}
+        onArchive={handleArchiveSession}
+        onShare={handleShareSession}
+        onMoveToProject={handleMoveToProjectSession}
+        className="bg-[var(--chat-sidebar-bg)] border-[var(--chat-border-strong)]"
       />
 
       {/* Main area + artifact workbench */}

--- a/apps/web/lib/chat/webChatPort.ts
+++ b/apps/web/lib/chat/webChatPort.ts
@@ -1,0 +1,559 @@
+'use client';
+
+/**
+ * Web implementation of the `@agiworkforce/stores` `ChatStorePort`.
+ *
+ * This is the load-bearing transport seam between the shared vanilla chat store
+ * (`createChatStore`) and the web surface's backend:
+ *   - `sendChat`   → SSE fetch to `/api/llm/v1/chat/completions`
+ *   - `loadConversations` / CRUD → `/api/chat/conversations`
+ *   - `persistMessage` → `POST /api/chat/conversations/{id}/messages` (skipLlm)
+ *
+ * The port does NOT import `next/navigation`, `zustand`, or any store directly.
+ * It takes a `getToken` function (from `@clerk/nextjs useAuth().getToken`) and
+ * the web CSRF helper as constructor params so the port stays tree-shakeable and
+ * testable without a full Next.js environment.
+ *
+ * IMPORTANT: The actual `/chat` page (`WebChatPage.tsx`) currently wires its
+ * streaming through `useChatStream.ts`, which calls `useChatStore` methods that
+ * have the same signatures as the shared store's actions (by design). The shared
+ * store's method names intentionally match — see `packages/stores/src/chat/chatStore.ts`
+ * header comment. This file formalises the port contract and is used by any
+ * consumer that wants to instantiate the shared `createChatStore` with web's
+ * transport (e.g. the desktop-parity proof slice).
+ *
+ * @module lib/chat/webChatPort
+ */
+
+import type {
+  ChatStorePort,
+  SendChatParams,
+  SendChatCallbacks,
+  ChatConversation,
+  ChatMessage,
+  ChatToolEntry,
+} from '@agiworkforce/stores';
+import { addCsrfHeaders } from '@/lib/client/csrf';
+import {
+  createSendReplayMetadata,
+  hasWebSearchSources,
+} from '@/features/chat/types/message-metadata';
+import {
+  buildFreeTrialPaywallSlot,
+  isFreeTrialErrorCode,
+} from '@/features/chat/stores/freeTrialStore';
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function readChatApiError(payload: unknown, fallback: string): { message: string; code?: string } {
+  if (!payload || typeof payload !== 'object') return { message: fallback };
+  const body = payload as Record<string, unknown>;
+  const topMessage = readString(body['message']);
+  const topCode = readString(body['code']);
+  const error = body['error'];
+  if (typeof error === 'string') return { message: readString(error) ?? fallback, code: topCode };
+  if (error && typeof error === 'object') {
+    const eb = error as Record<string, unknown>;
+    return {
+      message: readString(eb['message']) ?? topMessage ?? fallback,
+      code: readString(eb['code']) ?? topCode,
+    };
+  }
+  return { message: topMessage ?? fallback, code: topCode };
+}
+
+// Minimum byte look-back to avoid splitting a `</thinking>` marker across chunks.
+const HOLD_BACK = 11;
+
+// ---------------------------------------------------------------------------
+// Port factory
+// ---------------------------------------------------------------------------
+
+export interface WebChatPortOptions {
+  /** Token getter from Clerk `useAuth().getToken`. */
+  getToken: () => Promise<string | null>;
+}
+
+/**
+ * Build a `ChatStorePort` wired against the web API surface.
+ *
+ * @example
+ * ```ts
+ * const { getToken } = useAuth();
+ * const port = makeWebChatPort({ getToken });
+ * const store = createChatStore({ port, initialModelId: 'auto-balanced' });
+ * ```
+ */
+export function makeWebChatPort(options: WebChatPortOptions): ChatStorePort {
+  const { getToken } = options;
+
+  // --- helpers ---
+
+  async function authedHeaders(extra?: Record<string, string>) {
+    const token = await getToken();
+    if (!token) throw new Error('Not authenticated');
+    return addCsrfHeaders({
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      ...(extra ?? {}),
+    });
+  }
+
+  // --- port methods ---
+
+  const loadConversations: ChatStorePort['loadConversations'] = async () => {
+    const headers = await authedHeaders();
+    const res = await fetch('/api/chat/conversations', { headers });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(readChatApiError(err, 'Failed to fetch conversations').message);
+    }
+    const data = await res.json();
+    return ((data.conversations ?? []) as Record<string, unknown>[]).map(
+      (c): ChatConversation => ({
+        id: String(c['id'] ?? ''),
+        title: String(c['title'] ?? ''),
+        updatedAt: String(c['updated_at'] ?? new Date().toISOString()),
+        pinned: Boolean(c['pinned']),
+        projectId: (c['project_id'] as string | null) ?? null,
+      }),
+    );
+  };
+
+  const createRemoteConversation: ChatStorePort['createRemoteConversation'] = async (title) => {
+    const headers = await authedHeaders();
+    const res = await fetch('/api/chat/conversations', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ title: title ?? 'New Chat' }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(readChatApiError(err, 'Failed to create conversation').message);
+    }
+    const data = await res.json();
+    const c = data.conversation as Record<string, unknown>;
+    return {
+      id: String(c['id'] ?? ''),
+      title: String(c['title'] ?? ''),
+      updatedAt: String(c['updated_at'] ?? new Date().toISOString()),
+    };
+  };
+
+  const loadConversationMessages: ChatStorePort['loadConversationMessages'] = async (id) => {
+    const headers = await authedHeaders();
+    const res = await fetch(`/api/chat/conversations/${id}`, { headers });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(readChatApiError(err, 'Failed to load conversation').message);
+    }
+    const data = await res.json();
+    return ((data.messages ?? []) as Record<string, unknown>[]).map(
+      (m): ChatMessage => ({
+        id: String(m['id'] ?? ''),
+        conversationId: id,
+        role: (m['role'] as 'user' | 'assistant' | 'system') ?? 'assistant',
+        content: String(m['content'] ?? ''),
+        createdAt: String(m['created_at'] ?? new Date().toISOString()),
+        model: m['model'] as string | undefined,
+        metadata: m['metadata'] as Record<string, unknown> | undefined,
+      }),
+    );
+  };
+
+  const persistMessage: ChatStorePort['persistMessage'] = async (conversationId, message) => {
+    const headers = await authedHeaders();
+    await fetch(`/api/chat/conversations/${conversationId}/messages`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        id: message.id,
+        role: message.role,
+        content: message.content,
+        model: message.model,
+        metadata: message.metadata,
+        skipLlm: true,
+      }),
+    });
+  };
+
+  const deleteRemoteConversation: ChatStorePort['deleteRemoteConversation'] = async (id) => {
+    const headers = await authedHeaders();
+    const res = await fetch(`/api/chat/conversations/${id}`, {
+      method: 'DELETE',
+      headers,
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(readChatApiError(err, 'Failed to delete conversation').message);
+    }
+  };
+
+  /**
+   * Core send: SSE fetch to `/api/llm/v1/chat/completions`.
+   *
+   * Mirrors the logic in `useChatStream.ts` exactly (same chunk parsing,
+   * thinking-block detection, tool-status, search-results, code-execution)
+   * but routes events through the shared port callbacks instead of calling
+   * the store directly. This lets the shared `createChatStore.send()` drive
+   * streaming from the same backend without coupling to web's React store.
+   */
+  const sendChat: ChatStorePort['sendChat'] = async (
+    params: SendChatParams,
+    callbacks: SendChatCallbacks,
+  ) => {
+    const {
+      conversationId: _conversationId,
+      assistantMessageId,
+      content: _content,
+      model,
+      messages,
+      webSearch,
+      thinkingEnabled,
+      codeExecution,
+      effort,
+      extra,
+      signal,
+    } = params;
+
+    const skillBody = extra?.['skillBody'] as string | undefined;
+    const styleMode = extra?.['styleMode'] as string | undefined;
+
+    const sendReplay = createSendReplayMetadata({
+      webSearchEnabled: webSearch,
+      thinkingEnabled,
+      codeExecutionEnabled: codeExecution,
+      styleMode,
+      hasSkillInstruction: Boolean(skillBody),
+    });
+
+    const token = await getToken();
+    if (!token) {
+      callbacks.onError('Not authenticated');
+      return;
+    }
+
+    type MessageContent =
+      | string
+      | Array<{ type: string; text?: string; image_url?: { url: string } }>;
+    type ApiMessage = { role: string; content: MessageContent };
+
+    const apiMessages: ApiMessage[] = messages
+      .filter((m) => m.id !== assistantMessageId)
+      .map((m) => ({ role: m.role, content: m.content as MessageContent }));
+
+    if (skillBody) apiMessages.unshift({ role: 'system', content: skillBody });
+
+    const STYLE_INSTRUCTIONS: Record<string, string> = {
+      concise: 'Be concise. Give short, direct answers without unnecessary detail.',
+      formal: 'Use formal, professional language. Be precise and structured.',
+      explanatory: 'Be thorough and educational. Explain concepts in detail with examples.',
+    };
+    if (styleMode && styleMode !== 'normal') {
+      const inst = STYLE_INSTRUCTIONS[styleMode];
+      if (inst) apiMessages.unshift({ role: 'system', content: inst });
+    }
+
+    const headers = await addCsrfHeaders({
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    });
+
+    const response = await fetch('/api/llm/v1/chat/completions', {
+      method: 'POST',
+      headers,
+      signal,
+      body: JSON.stringify({
+        model,
+        messages: apiMessages,
+        stream: true,
+        web_search: webSearch || undefined,
+        code_execution: codeExecution || undefined,
+        thinking_mode: thinkingEnabled || undefined,
+        effort: thinkingEnabled ? effort : undefined,
+        use_prompt_cache: true,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      const { message, code } = readChatApiError(errorData, `Request failed: ${response.status}`);
+
+      if (isFreeTrialErrorCode(code)) {
+        callbacks.onMessagePatch({
+          isStreaming: false,
+          content: '',
+          metadata: {
+            paywall: buildFreeTrialPaywallSlot(code!, message),
+          },
+        });
+        callbacks.onError(message);
+        return;
+      }
+      throw new Error(message);
+    }
+
+    if (!response.body) throw new Error('No response body');
+
+    // ---- SSE parsing (mirrors useChatStream.ts) ----
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let fullContent = '';
+    let inThinkingBlock = false;
+    let contentBuffer = '';
+
+    const toolTimeline: ChatToolEntry[] = [];
+    const toolStartTimes = new Map<string, number>();
+    let currentSearchResults: Array<{ url: string; title: string; snippet: string }> | undefined;
+
+    const publishTools = () => {
+      if (toolTimeline.length === 0) return;
+      callbacks.onToolTimeline(toolTimeline.map((t) => ({ ...t })));
+    };
+
+    const findLastTool = (name: string, statuses?: ChatToolEntry['status'][]) => {
+      for (let i = toolTimeline.length - 1; i >= 0; i--) {
+        const t = toolTimeline[i];
+        if (!t || t.name !== name) continue;
+        if (!statuses || statuses.includes(t.status)) return i;
+      }
+      return -1;
+    };
+
+    const startTool = (rawName: unknown, args?: string) => {
+      const name = typeof rawName === 'string' && rawName.trim() ? rawName.trim() : 'server_tool';
+      const idx = findLastTool(name, ['pending', 'running']);
+      if (idx >= 0) {
+        const t = toolTimeline[idx];
+        if (t) {
+          t.status = 'running';
+          t.args = args ?? t.args;
+        }
+        publishTools();
+        return;
+      }
+      const id = `${assistantMessageId}-${name.replace(/[^a-z0-9_-]/gi, '-').toLowerCase()}-${toolTimeline.length + 1}`;
+      toolStartTimes.set(id, Date.now());
+      toolTimeline.push({ id, name, status: 'running', args });
+      publishTools();
+    };
+
+    const finishTool = (rawName: unknown, status: 'completed' | 'failed', error?: string) => {
+      const name = typeof rawName === 'string' && rawName.trim() ? rawName.trim() : 'server_tool';
+      let idx = findLastTool(name, ['pending', 'running']);
+      if (idx < 0) {
+        const id = `${assistantMessageId}-${name}-${toolTimeline.length + 1}`;
+        toolStartTimes.set(id, Date.now());
+        toolTimeline.push({ id, name, status: 'running' });
+        idx = toolTimeline.length - 1;
+      }
+      const t = toolTimeline[idx];
+      if (!t) return;
+      const start = t.id ? toolStartTimes.get(t.id) : undefined;
+      t.status = status;
+      t.durationMs = start ? Date.now() - start : t.durationMs;
+      t.error = error;
+      publishTools();
+    };
+
+    const finishRunning = (status: 'completed' | 'failed' = 'completed', error?: string) => {
+      for (const t of toolTimeline) {
+        if (t.status !== 'pending' && t.status !== 'running') continue;
+        const start = t.id ? toolStartTimes.get(t.id) : undefined;
+        t.status = status;
+        t.durationMs = start ? Date.now() - start : t.durationMs;
+        t.error = error;
+      }
+      publishTools();
+    };
+
+    const flushContent = (isFinal = false) => {
+      while (true) {
+        const openIdx = contentBuffer.indexOf('<thinking>');
+        const closeIdx = contentBuffer.indexOf('</thinking>');
+
+        if (!inThinkingBlock && openIdx !== -1) {
+          const before = contentBuffer.slice(0, openIdx);
+          if (before) {
+            fullContent += before;
+            callbacks.onContent(before);
+          }
+          inThinkingBlock = true;
+          callbacks.onMessagePatch({
+            metadata: { isThinkingStreaming: true, thinkingStartedAt: new Date().toISOString() },
+          });
+          contentBuffer = contentBuffer.slice(openIdx + '<thinking>'.length);
+          continue;
+        }
+
+        if (inThinkingBlock && closeIdx !== -1) {
+          const part = contentBuffer.slice(0, closeIdx);
+          if (part) callbacks.onThinking(part);
+          inThinkingBlock = false;
+          callbacks.onMessagePatch({
+            metadata: { isThinkingStreaming: false, thinkingCompletedAt: new Date().toISOString() },
+          });
+          contentBuffer = contentBuffer.slice(closeIdx + '</thinking>'.length);
+          continue;
+        }
+
+        if (isFinal) {
+          if (contentBuffer) {
+            if (inThinkingBlock) callbacks.onThinking(contentBuffer);
+            else {
+              fullContent += contentBuffer;
+              callbacks.onContent(contentBuffer);
+            }
+            contentBuffer = '';
+          }
+        } else if (contentBuffer.length > HOLD_BACK) {
+          const safe = contentBuffer.slice(0, contentBuffer.length - HOLD_BACK);
+          if (inThinkingBlock) callbacks.onThinking(safe);
+          else {
+            fullContent += safe;
+            callbacks.onContent(safe);
+          }
+          contentBuffer = contentBuffer.slice(contentBuffer.length - HOLD_BACK);
+        }
+        break;
+      }
+    };
+
+    const handleDone = () => {
+      flushContent(true);
+      if (inThinkingBlock) {
+        callbacks.onMessagePatch({
+          metadata: { isThinkingStreaming: false, thinkingCompletedAt: new Date().toISOString() },
+        });
+        inThinkingBlock = false;
+      }
+      finishRunning();
+      callbacks.onSearching(false);
+      callbacks.onExecutingCode(false);
+      if (sendReplay && fullContent) {
+        callbacks.onMessagePatch({ metadata: { sendReplay } });
+      }
+      if (currentSearchResults && hasWebSearchSources(currentSearchResults)) {
+        callbacks.onSearchResults(currentSearchResults);
+      }
+      callbacks.onDone();
+    };
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith('data: ')) continue;
+        const data = trimmed.slice(6);
+        if (data === '[DONE]') {
+          handleDone();
+          return;
+        }
+
+        try {
+          const parsed = JSON.parse(data);
+
+          let chunk: string | null = null;
+          if (parsed.choices?.[0]?.delta?.content != null) {
+            chunk = parsed.choices[0].delta.content;
+          } else if (parsed.type === 'content_block_delta' && parsed.delta?.text) {
+            chunk = parsed.delta.text;
+          }
+          if (chunk !== null) {
+            contentBuffer += chunk;
+            flushContent(false);
+          }
+
+          const toolStatus = parsed.choices?.[0]?.delta?.x_tool_status;
+          if (toolStatus?.type === 'server_tool_use') startTool(toolStatus.name, toolStatus.status);
+          if (toolStatus?.status === 'searching' || toolStatus?.status === 'fetching') {
+            callbacks.onSearching(true);
+          } else if (toolStatus?.status === 'executing') {
+            callbacks.onExecutingCode(true);
+          }
+
+          const codeResult = parsed.choices?.[0]?.delta?.x_code_result;
+          if (codeResult) {
+            const items = Array.isArray(codeResult.content)
+              ? (codeResult.content as Record<string, unknown>[])
+              : [];
+            const textItem = items.find((c) => c['type'] === 'text');
+            const rawText = (textItem?.['text'] as string) || '';
+            const images = items
+              .filter((c) => c['type'] === 'image')
+              .map((c) => {
+                const src = c['source'] as Record<string, unknown> | undefined;
+                return {
+                  mediaType: (src?.['media_type'] as string) || 'image/png',
+                  data: (src?.['data'] as string) || '',
+                };
+              })
+              .filter((img) => img.data);
+            const stdout = rawText.match(/<stdout>([\s\S]*?)<\/stdout>/)?.[1] ?? rawText;
+            const stderr = rawText.match(/<stderr>([\s\S]*?)<\/stderr>/)?.[1] ?? '';
+            const returnCode = parseInt(
+              rawText.match(/<return_code>(\d+)<\/return_code>/)?.[1] ?? '0',
+              10,
+            );
+            callbacks.onCodeExecutionResult({
+              stdout,
+              stderr,
+              returnCode,
+              images: images.length > 0 ? images : undefined,
+            });
+            finishTool('code_execution', 'completed');
+          }
+
+          const searchBlock = parsed.choices?.[0]?.delta?.x_search_results;
+          if (searchBlock?.content && Array.isArray(searchBlock.content)) {
+            const results = (searchBlock.content as Record<string, unknown>[])
+              .filter((r) => r['type'] === 'web_search_result' && r['url'])
+              .map((r) => ({
+                url: r['url'] as string,
+                title: (r['title'] as string) || (r['url'] as string),
+                snippet: (r['encrypted_content'] as string) || '',
+              }));
+            if (results.length > 0) {
+              currentSearchResults = results;
+              callbacks.onSearchResults(results);
+              finishTool('web_search', 'completed');
+            }
+          }
+
+          if (parsed.choices?.[0]?.finish_reason || parsed.type === 'message_stop') {
+            callbacks.onMessagePatch({ isStreaming: false });
+          }
+        } catch {
+          // ignore partial chunks
+        }
+      }
+    }
+
+    // No [DONE] received — flush and finalize
+    flushContent(true);
+    finishRunning();
+    callbacks.onDone();
+  };
+
+  return {
+    loadConversations,
+    createRemoteConversation,
+    loadConversationMessages,
+    persistMessage,
+    deleteRemoteConversation,
+    sendChat,
+  };
+}

--- a/apps/web/lib/csrf.ts
+++ b/apps/web/lib/csrf.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from 'crypto';
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
 import { auth } from '@clerk/nextjs/server';
 
 // Lazily get CSRF_SECRET to avoid errors during build/static generation.
@@ -28,7 +28,20 @@ function getCsrfSecret(): string {
   }
   const secret = process.env['CSRF_SECRET'];
   if (!secret) {
-    throw new Error('CSRF_SECRET environment variable is required');
+    // CSRF_SECRET is not set. Log a server-side warning and return a per-process
+    // random sentinel so that CSRF verification always fails for non-Bearer
+    // requests (a clean 403) rather than crashing the handler with a 500.
+    // Bearer-authenticated requests are already bypassed before this is called.
+    // Operators must set CSRF_SECRET in production to secure cookie-session flows.
+    console.error(
+      '[csrf] CRITICAL: CSRF_SECRET environment variable is not set. ' +
+        'Cookie-session CSRF protection is DISABLED. ' +
+        'Set CSRF_SECRET (≥32 bytes) in your Vercel/environment config. ' +
+        'Bearer-authenticated requests (web app) are unaffected.',
+    );
+    // Sentinel: random 64-char hex that never matches any real token.
+    cachedSecret = randomBytes(32).toString('hex');
+    return cachedSecret;
   }
   assertSufficientEntropy('CSRF_SECRET', secret);
   cachedSecret = secret;

--- a/apps/web/lib/managed-compute-gate.ts
+++ b/apps/web/lib/managed-compute-gate.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { NextRequest, NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
 
 export const MANAGED_COMPUTE_PRIVATE_BETA_ENV = 'AGI_MANAGED_COMPUTE_PRIVATE_BETA';
 export const MANAGED_COMPUTE_BETA_HEADER = 'x-agi-managed-compute-beta';
@@ -10,6 +11,14 @@ export interface ManagedComputeDescriptor {
   provider: string;
   model: string;
   feature?: string;
+  /**
+   * When true, this request is a free-tier trial prompt. Free trial prompts
+   * are always allowed through regardless of the private-beta flag so that
+   * brand-new users can experience the product without an infra gate in the way.
+   * Set this only after the auth gate has confirmed the subscription is 'free'
+   * and the model is in the economy allow-list.
+   */
+  isFreeTrial?: boolean;
 }
 
 function headerValue(request: NextRequest, name: string): string | null {
@@ -34,10 +43,22 @@ export function buildManagedComputeGateResponse(
   };
 
   if (!isManagedComputePrivateBetaEnabled()) {
+    // Free-trial prompts are always allowed through so new users can chat
+    // without needing the private-beta env var. All other managed-compute
+    // requests are gated until the flag is set.
+    if (descriptor.isFreeTrial) {
+      logger.info(
+        { feature: base.feature, model: base.model },
+        '[managed-compute-gate] free-trial request allowed through without private-beta flag',
+      );
+      return null;
+    }
+
     return NextResponse.json(
       {
         error: {
-          message: 'Managed compute is private beta only.',
+          message:
+            'Managed compute is not yet available. Join the waitlist at agiworkforce.com/pricing.',
           type: 'managed_compute_private_beta',
           code: 'public_launch_blocked',
         },

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -14,6 +14,7 @@
     "@agiworkforce/api": "workspace:*",
     "@agiworkforce/runtime": "workspace:*",
     "@agiworkforce/types": "workspace:*",
+    "@agiworkforce/unified-chat": "workspace:*",
     "zustand": "^5.0.12",
     "immer": "^11.1.4"
   }

--- a/packages/stores/src/chat/chatStore.ts
+++ b/packages/stores/src/chat/chatStore.ts
@@ -1,0 +1,580 @@
+/**
+ * Shared, platform-agnostic chat store.
+ *
+ * Returns a Zustand **vanilla** store (`createStore`) so each surface can wrap
+ * it with its own React bindings (`useStore` / `create`) and persist storage.
+ * The store is PURE: no `next/`, no `@tauri-apps`, no `fetch` literal, no DOM
+ * or node-only globals. All IO is injected through a {@link ChatStorePort}
+ * adapter passed to {@link createChatStore}. Web wires the port against
+ * `fetch('/api/llm/v1/chat/completions')`; desktop wires it against Tauri
+ * `invoke(...)`; mobile wires its own transport.
+ *
+ * Data model: a SUPERSET of both existing surfaces.
+ *   - `messagesByConversation` map (desktop model) is the source of truth.
+ *   - `messages` is the active-conversation mirror (web model) kept in sync.
+ *   - streaming/tool/search/code-exec helpers (web model) are first-class.
+ *
+ * The method names + semantics intentionally match the web store
+ * (`addMessage` / `updateMessage` / `appendToMessage` / `appendToThinking` /
+ * `setToolTimeline` / `startStreaming` / `stopStreaming` / `setError` …) so the
+ * web `useChatStream` can migrate onto this store without changing call sites.
+ *
+ * @module chat/chatStore
+ */
+
+import { createStore, type StoreApi } from 'zustand/vanilla';
+import type {
+  ChatMessage,
+  ChatConversation,
+  ChatToolEntry,
+  ChatSearchResult,
+  ChatCodeExecutionResult,
+  CreateConversationOptions,
+  ChatStorePort,
+  SendChatParams,
+  SendChatCallbacks,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// State + actions
+// ---------------------------------------------------------------------------
+
+export interface ChatStoreState {
+  // --- conversation data ---
+  conversations: ChatConversation[];
+  activeConversationId: string | null;
+  /** Source-of-truth per-conversation message lists (desktop model). */
+  messagesByConversation: Record<string, ChatMessage[]>;
+  /** Active-conversation mirror (web model). Always equals
+   *  `messagesByConversation[activeConversationId]`. */
+  messages: ChatMessage[];
+
+  // --- ui / lifecycle flags ---
+  isStreaming: boolean;
+  isLoading: boolean;
+  isLoadingMessages: boolean;
+  error: string | null;
+
+  // --- model selection ---
+  selectedModelId: string;
+
+  // --- pure state actions (no IO) ---
+  /** Ensure there is an active conversation; create one if none. Returns its id. */
+  ensureActiveConversation: () => string;
+  /** Create a local conversation (no remote call). Returns the new id. */
+  createConversation: (title?: string, opts?: CreateConversationOptions) => string;
+  selectConversation: (id: string) => void;
+  setConversations: (conversations: ChatConversation[]) => void;
+  setConversationMessages: (id: string, messages: ChatMessage[]) => void;
+  renameConversation: (id: string, title: string) => void;
+  deleteConversation: (id: string) => void;
+  togglePinnedConversation: (id: string) => void;
+  archiveConversation: (id: string) => void;
+  restoreConversation: (id: string) => void;
+  setConversationProject: (id: string, projectId: string | null) => void;
+
+  addMessage: (message: ChatMessage) => string;
+  /** Optimistic message helpers — message carries its own client id. */
+  addOptimisticMessage: (message: ChatMessage) => string;
+  confirmOptimisticMessage: (clientId: string, patch?: Partial<ChatMessage>) => void;
+  failOptimisticMessage: (clientId: string, error: string) => void;
+  updateMessage: (id: string, patch: Partial<ChatMessage>) => void;
+  appendToMessage: (id: string, chunk: string) => void;
+  appendToThinking: (id: string, chunk: string) => void;
+  setToolTimeline: (id: string, tools: ChatToolEntry[]) => void;
+  updateToolEntry: (id: string, toolCallId: string, patch: Partial<ChatToolEntry>) => void;
+  setSearching: (id: string, isSearching: boolean) => void;
+  setSearchResults: (id: string, results: ChatSearchResult[]) => void;
+  setExecutingCode: (id: string, isExecuting: boolean) => void;
+  setCodeExecutionResult: (id: string, result: ChatCodeExecutionResult) => void;
+  deleteMessage: (id: string) => void;
+
+  startStreaming: (id: string) => void;
+  stopStreaming: () => void;
+  setLoading: (loading: boolean) => void;
+  setLoadingMessages: (loading: boolean) => void;
+  setError: (error: string | null) => void;
+  setSelectedModel: (modelId: string) => void;
+  reset: () => void;
+
+  // --- async actions (delegate to the injected port) ---
+  /** Load the conversation list via `port.loadConversations`. */
+  loadConversations: () => Promise<void>;
+  /** Load messages for a conversation via `port.loadConversationMessages`. */
+  loadConversationMessages: (id: string) => Promise<void>;
+  /**
+   * Send a user turn. Adds the user + optimistic assistant messages, then
+   * delegates the transport to `port.sendChat`, forwarding stream events to the
+   * matching state actions. Resolves when the stream completes.
+   */
+  send: (params: SendUserMessageParams) => Promise<void>;
+}
+
+/** Params for the high-level `send` action. */
+export interface SendUserMessageParams {
+  content: string;
+  /** Override the conversation to send into; defaults to the active one. */
+  conversationId?: string;
+  /** Override the model; defaults to `selectedModelId`. */
+  model?: string;
+  webSearch?: boolean;
+  thinkingEnabled?: boolean;
+  codeExecution?: boolean;
+  effort?: string;
+  /** Surface-specific extras forwarded verbatim to the port. */
+  extra?: Record<string, unknown>;
+  signal?: AbortSignal;
+  /** Factory for ids (defaults to a built-in generator). */
+  generateId?: () => string;
+}
+
+export type ChatStore = StoreApi<ChatStoreState>;
+
+/** Options for {@link createChatStore}. */
+export interface CreateChatStoreOptions {
+  /** The injected transport boundary. Required: at minimum it must provide `sendChat`. */
+  port: ChatStorePort;
+  /** Initial model id. The store never invents a default literal of its own. */
+  initialModelId?: string;
+  /** Id generator (testable seam). Defaults to a time+random string. */
+  generateId?: () => string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (pure)
+// ---------------------------------------------------------------------------
+
+function defaultGenerateId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** Immutably map the messages of one conversation, keeping the active mirror in sync. */
+function patchConversationMessages(
+  state: ChatStoreState,
+  conversationId: string | null,
+  mapFn: (messages: ChatMessage[]) => ChatMessage[],
+): Pick<ChatStoreState, 'messagesByConversation' | 'messages'> {
+  if (!conversationId) {
+    return {
+      messagesByConversation: state.messagesByConversation,
+      messages: state.messages,
+    };
+  }
+  const current = state.messagesByConversation[conversationId] ?? [];
+  const next = mapFn(current);
+  const messagesByConversation = {
+    ...state.messagesByConversation,
+    [conversationId]: next,
+  };
+  return {
+    messagesByConversation,
+    messages: conversationId === state.activeConversationId ? next : state.messages,
+  };
+}
+
+/** Find which conversation a message id belongs to (active first, then any). */
+function findConversationOfMessage(state: ChatStoreState, messageId: string): string | null {
+  if (
+    state.activeConversationId &&
+    (state.messagesByConversation[state.activeConversationId] ?? []).some((m) => m.id === messageId)
+  ) {
+    return state.activeConversationId;
+  }
+  for (const [convId, msgs] of Object.entries(state.messagesByConversation)) {
+    if (msgs.some((m) => m.id === messageId)) return convId;
+  }
+  return null;
+}
+
+/** Patch a single message by id wherever it lives. */
+function patchMessageById(
+  state: ChatStoreState,
+  messageId: string,
+  patch: (message: ChatMessage) => ChatMessage,
+): Pick<ChatStoreState, 'messagesByConversation' | 'messages'> {
+  const convId = findConversationOfMessage(state, messageId);
+  return patchConversationMessages(state, convId, (msgs) =>
+    msgs.map((m) => (m.id === messageId ? patch(m) : m)),
+  );
+}
+
+/** Read surface-metadata bag off a message (kept generic — see ChatMessage.metadata). */
+function withMetadata(message: ChatMessage, patch: Record<string, unknown>): ChatMessage {
+  return { ...message, metadata: { ...message.metadata, ...patch } };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a platform-agnostic chat store.
+ *
+ * @example
+ * // web
+ * const store = createChatStore({ port: webChatPort, initialModelId });
+ * const useChat = (sel) => useStore(store, sel); // React binding owned by surface
+ */
+export function createChatStore(options: CreateChatStoreOptions): ChatStore {
+  const { port, initialModelId = '', generateId = defaultGenerateId } = options;
+
+  if (typeof port.sendChat !== 'function') {
+    throw new Error('createChatStore: port.sendChat is required');
+  }
+
+  const initialState = {
+    conversations: [] as ChatConversation[],
+    activeConversationId: null as string | null,
+    messagesByConversation: {} as Record<string, ChatMessage[]>,
+    messages: [] as ChatMessage[],
+    isStreaming: false,
+    isLoading: false,
+    isLoadingMessages: false,
+    error: null as string | null,
+    selectedModelId: initialModelId,
+  };
+
+  return createStore<ChatStoreState>((set, get) => ({
+    ...initialState,
+
+    // ---- conversations (pure) ----
+    ensureActiveConversation: () => {
+      const { activeConversationId } = get();
+      if (activeConversationId) return activeConversationId;
+      return get().createConversation();
+    },
+
+    createConversation: (title, opts) => {
+      const id = opts?.id ?? generateId();
+      const conversation: ChatConversation = {
+        id,
+        title: title ?? 'New chat',
+        updatedAt: new Date().toISOString(),
+        pinned: false,
+        archived: false,
+        projectId: opts?.projectId ?? null,
+        messageCount: 0,
+        ...(opts?.modelOverride !== undefined ? { modelOverride: opts.modelOverride } : {}),
+        ...(opts?.incognito !== undefined ? { incognito: opts.incognito } : {}),
+      };
+      const activate = opts?.activate ?? true;
+      set((state) => ({
+        conversations: [conversation, ...state.conversations],
+        messagesByConversation: { ...state.messagesByConversation, [id]: [] },
+        ...(activate ? { activeConversationId: id, messages: [], error: null } : {}),
+      }));
+      return id;
+    },
+
+    selectConversation: (id) =>
+      set((state) => ({
+        activeConversationId: id,
+        messages: state.messagesByConversation[id] ?? [],
+        error: null,
+      })),
+
+    setConversations: (conversations) => set({ conversations }),
+
+    setConversationMessages: (id, messages) =>
+      set((state) => ({
+        messagesByConversation: { ...state.messagesByConversation, [id]: messages },
+        messages: id === state.activeConversationId ? messages : state.messages,
+      })),
+
+    renameConversation: (id, title) =>
+      set((state) => ({
+        conversations: state.conversations.map((c) => (c.id === id ? { ...c, title } : c)),
+      })),
+
+    deleteConversation: (id) =>
+      set((state) => {
+        const { [id]: _removed, ...restMessages } = state.messagesByConversation;
+        void _removed;
+        const isActive = state.activeConversationId === id;
+        return {
+          conversations: state.conversations.filter((c) => c.id !== id),
+          messagesByConversation: restMessages,
+          activeConversationId: isActive ? null : state.activeConversationId,
+          messages: isActive ? [] : state.messages,
+        };
+      }),
+
+    togglePinnedConversation: (id) =>
+      set((state) => ({
+        conversations: state.conversations.map((c) =>
+          c.id === id ? { ...c, pinned: !c.pinned } : c,
+        ),
+      })),
+
+    archiveConversation: (id) =>
+      set((state) => ({
+        conversations: state.conversations.map((c) => (c.id === id ? { ...c, archived: true } : c)),
+      })),
+
+    restoreConversation: (id) =>
+      set((state) => ({
+        conversations: state.conversations.map((c) =>
+          c.id === id ? { ...c, archived: false } : c,
+        ),
+      })),
+
+    setConversationProject: (id, projectId) =>
+      set((state) => ({
+        conversations: state.conversations.map((c) => (c.id === id ? { ...c, projectId } : c)),
+      })),
+
+    // ---- messages (pure) ----
+    addMessage: (message) => {
+      const id = message.id || generateId();
+      const msg: ChatMessage = message.id ? message : { ...message, id };
+      set((state) => {
+        const convId = msg.conversationId ?? state.activeConversationId;
+        const patched = patchConversationMessages(state, convId, (msgs) => [...msgs, msg]);
+        return {
+          ...patched,
+          conversations: state.conversations.map((c) =>
+            c.id === convId
+              ? {
+                  ...c,
+                  messageCount: (c.messageCount ?? 0) + 1,
+                  updatedAt: new Date().toISOString(),
+                }
+              : c,
+          ),
+        };
+      });
+      return id;
+    },
+
+    addOptimisticMessage: (message) => {
+      const id = message.id || generateId();
+      const msg: ChatMessage = {
+        ...message,
+        id,
+        metadata: { ...message.metadata, optimistic: true },
+      };
+      set((state) => {
+        const convId = msg.conversationId ?? state.activeConversationId;
+        return patchConversationMessages(state, convId, (msgs) => [...msgs, msg]);
+      });
+      return id;
+    },
+
+    confirmOptimisticMessage: (clientId, patch) =>
+      set((state) =>
+        patchMessageById(state, clientId, (m) =>
+          withMetadata({ ...m, ...patch }, { optimistic: false }),
+        ),
+      ),
+
+    failOptimisticMessage: (clientId, error) =>
+      set((state) =>
+        patchMessageById(state, clientId, (m) =>
+          withMetadata({ ...m, error }, { optimistic: false, failed: true }),
+        ),
+      ),
+
+    updateMessage: (id, patch) =>
+      set((state) => patchMessageById(state, id, (m) => ({ ...m, ...patch }))),
+
+    appendToMessage: (id, chunk) =>
+      set((state) => patchMessageById(state, id, (m) => ({ ...m, content: m.content + chunk }))),
+
+    appendToThinking: (id, chunk) =>
+      set((state) =>
+        patchMessageById(state, id, (m) =>
+          withMetadata(m, {
+            thinkingContent:
+              ((m.metadata?.['thinkingContent'] as string | undefined) ?? '') + chunk,
+          }),
+        ),
+      ),
+
+    setToolTimeline: (id, tools) =>
+      set((state) => patchMessageById(state, id, (m) => withMetadata(m, { tools }))),
+
+    updateToolEntry: (id, toolCallId, patch) =>
+      set((state) =>
+        patchMessageById(state, id, (m) => {
+          const tools = (m.metadata?.['tools'] as ChatToolEntry[] | undefined) ?? [];
+          const next = tools.map((t) => (t.toolCallId === toolCallId ? { ...t, ...patch } : t));
+          return withMetadata(m, { tools: next });
+        }),
+      ),
+
+    setSearching: (id, isSearching) =>
+      set((state) => patchMessageById(state, id, (m) => withMetadata(m, { isSearching }))),
+
+    setSearchResults: (id, results) =>
+      set((state) =>
+        patchMessageById(state, id, (m) =>
+          withMetadata(m, { searchResults: results, isSearching: false }),
+        ),
+      ),
+
+    setExecutingCode: (id, isExecuting) =>
+      set((state) =>
+        patchMessageById(state, id, (m) => withMetadata(m, { isExecutingCode: isExecuting })),
+      ),
+
+    setCodeExecutionResult: (id, result) =>
+      set((state) =>
+        patchMessageById(state, id, (m) =>
+          withMetadata(m, { codeExecutionResult: result, isExecutingCode: false }),
+        ),
+      ),
+
+    deleteMessage: (id) =>
+      set((state) => {
+        const convId = findConversationOfMessage(state, id);
+        return patchConversationMessages(state, convId, (msgs) => msgs.filter((m) => m.id !== id));
+      }),
+
+    // ---- streaming flags ----
+    startStreaming: (id) =>
+      set((state) => {
+        const patched = patchMessageById(state, id, (m) => ({
+          ...m,
+          isStreaming: true,
+        }));
+        return { ...patched, isStreaming: true };
+      }),
+
+    stopStreaming: () =>
+      set((state) => {
+        if (!state.activeConversationId) return { isStreaming: false };
+        const patched = patchConversationMessages(state, state.activeConversationId, (msgs) =>
+          msgs.map((m) => (m.isStreaming ? { ...m, isStreaming: false } : m)),
+        );
+        return { ...patched, isStreaming: false };
+      }),
+
+    setLoading: (loading) => set({ isLoading: loading }),
+    setLoadingMessages: (loading) => set({ isLoadingMessages: loading }),
+    setError: (error) => set({ error }),
+    setSelectedModel: (modelId) => set({ selectedModelId: modelId }),
+    reset: () => set({ ...initialState }),
+
+    // ---- async (delegate to port) ----
+    loadConversations: async () => {
+      if (!port.loadConversations) return;
+      set({ isLoading: true, error: null });
+      try {
+        const conversations = await port.loadConversations();
+        set({ conversations, isLoading: false });
+      } catch (err) {
+        set({
+          isLoading: false,
+          error: err instanceof Error ? err.message : 'Failed to load conversations',
+        });
+      }
+    },
+
+    loadConversationMessages: async (id) => {
+      if (!port.loadConversationMessages) return;
+      set({ isLoadingMessages: true, error: null });
+      try {
+        const messages = await port.loadConversationMessages(id);
+        set((state) => ({
+          isLoadingMessages: false,
+          messagesByConversation: {
+            ...state.messagesByConversation,
+            [id]: messages,
+          },
+          messages: id === state.activeConversationId ? messages : state.messages,
+        }));
+      } catch (err) {
+        set({
+          isLoadingMessages: false,
+          error: err instanceof Error ? err.message : 'Failed to load messages',
+        });
+      }
+    },
+
+    send: async (params) => {
+      const genId = params.generateId ?? generateId;
+      const conversationId = params.conversationId ?? get().ensureActiveConversation();
+      const model = params.model ?? get().selectedModelId;
+      const nowIso = new Date().toISOString();
+
+      // 1. user message
+      const userMessage: ChatMessage = {
+        id: genId(),
+        conversationId,
+        role: 'user',
+        content: params.content,
+        createdAt: nowIso,
+      };
+      get().addMessage(userMessage);
+      void port.persistMessage?.(conversationId, userMessage);
+
+      // 2. optimistic assistant placeholder
+      const assistantMessageId = genId();
+      const assistantMessage: ChatMessage = {
+        id: assistantMessageId,
+        conversationId,
+        role: 'assistant',
+        content: '',
+        createdAt: new Date().toISOString(),
+        model,
+        isStreaming: true,
+      };
+      get().addMessage(assistantMessage);
+      get().startStreaming(assistantMessageId);
+      set({ error: null });
+
+      // 3. bind stream callbacks → store actions (names match web useChatStream)
+      const callbacks: SendChatCallbacks = {
+        onContent: (chunk) => get().appendToMessage(assistantMessageId, chunk),
+        onThinking: (chunk) => get().appendToThinking(assistantMessageId, chunk),
+        onToolTimeline: (tools) => get().setToolTimeline(assistantMessageId, tools),
+        onToolEntry: (toolCallId, patch) =>
+          get().updateToolEntry(assistantMessageId, toolCallId, patch),
+        onSearching: (isSearching) => get().setSearching(assistantMessageId, isSearching),
+        onSearchResults: (results) => get().setSearchResults(assistantMessageId, results),
+        onExecutingCode: (isExecuting) => get().setExecutingCode(assistantMessageId, isExecuting),
+        onCodeExecutionResult: (result) => get().setCodeExecutionResult(assistantMessageId, result),
+        onMessagePatch: (patch) => get().updateMessage(assistantMessageId, patch),
+        onDone: () => {
+          get().stopStreaming();
+          const finalMessage = (get().messagesByConversation[conversationId] ?? []).find(
+            (m) => m.id === assistantMessageId,
+          );
+          if (finalMessage) {
+            void port.persistMessage?.(conversationId, finalMessage);
+          }
+        },
+        onError: (message) => {
+          get().updateMessage(assistantMessageId, {
+            isStreaming: false,
+            error: message,
+          });
+          get().stopStreaming();
+          get().setError(message);
+        },
+      };
+
+      const sendParams: SendChatParams = {
+        conversationId,
+        assistantMessageId,
+        content: params.content,
+        model,
+        messages: get().messagesByConversation[conversationId] ?? [],
+        ...(params.webSearch !== undefined ? { webSearch: params.webSearch } : {}),
+        ...(params.thinkingEnabled !== undefined
+          ? { thinkingEnabled: params.thinkingEnabled }
+          : {}),
+        ...(params.codeExecution !== undefined ? { codeExecution: params.codeExecution } : {}),
+        ...(params.effort !== undefined ? { effort: params.effort } : {}),
+        ...(params.extra !== undefined ? { extra: params.extra } : {}),
+        ...(params.signal !== undefined ? { signal: params.signal } : {}),
+      };
+
+      try {
+        await port.sendChat(sendParams, callbacks);
+      } catch (err) {
+        callbacks.onError(err instanceof Error ? err.message : 'Failed to send message');
+      }
+    },
+  }));
+}

--- a/packages/stores/src/chat/types.ts
+++ b/packages/stores/src/chat/types.ts
@@ -1,0 +1,195 @@
+/**
+ * Shared chat-store contracts.
+ *
+ * These types are the platform-agnostic superset of the desktop chat store
+ * (`apps/desktop/src/stores/chat/*` — `messagesByConversation` map model) and
+ * the web chat store (`apps/web/stores/chatStore.ts` — flat `messages[]` mirror
+ * + streaming/tool helpers). They MUST stay free of any surface-specific
+ * imports (no `next/`, no `@tauri-apps`, no DOM/node globals) so web, desktop,
+ * AND mobile can consume the same store.
+ *
+ * The canonical message contract is `ChatMessage` from `@agiworkforce/unified-chat`
+ * (the UI-tier shape). We re-export it here so consumers can import the message
+ * type from the same place as the store.
+ *
+ * @module chat/types
+ */
+
+import type { ChatMessage as UnifiedChatMessage } from '@agiworkforce/unified-chat';
+
+/** Canonical message shape — re-exported from `@agiworkforce/unified-chat`. */
+export type ChatMessage = UnifiedChatMessage;
+
+/**
+ * Status of a single tool invocation rendered in the assistant tool timeline.
+ * Superset of the desktop `ToolCall.status` and the web `MessageToolEntry.status`.
+ */
+export type ChatToolStatus = 'pending' | 'running' | 'completed' | 'failed' | 'awaiting_approval';
+
+/**
+ * One entry in the assistant message tool timeline. Mirrors the web store's
+ * `MessageToolEntry` so the web surface can map 1:1 without losing fields.
+ */
+export interface ChatToolEntry {
+  id?: string;
+  name: string;
+  status: ChatToolStatus;
+  durationMs?: number;
+  args?: string;
+  parameters?: Record<string, unknown>;
+  parallelGroup?: string;
+  error?: string;
+  /** When true, this tool call is blocked on user approval before execution. */
+  requiresApproval?: boolean;
+  /** Approval decision recorded by the user (true = approved, false = rejected). */
+  approved?: boolean;
+  /** Raw tool_call_id from the model, used for the approval round-trip. */
+  toolCallId?: string;
+  /** JSON args from the model, for display in the approval card. */
+  rawArgs?: Record<string, unknown>;
+  /** Tool result content after execution. */
+  result?: string;
+}
+
+/** Server-managed code-execution result attached to an assistant message. */
+export interface ChatCodeExecutionResult {
+  stdout: string;
+  stderr: string;
+  returnCode: number;
+  images?: Array<{ mediaType: string; data: string }>;
+}
+
+/** A single web-search result row attached to an assistant message. */
+export interface ChatSearchResult {
+  url: string;
+  title: string;
+  snippet: string;
+}
+
+/**
+ * Conversation summary — the platform-agnostic superset of the desktop
+ * `ConversationSummary` and the web `Conversation`.
+ *
+ * Field names are normalized to the desktop spelling (`pinned`/`archived`)
+ * because that is the spelling the shared `<Sidebar>` component consumes.
+ * The web surface maps its `isPinned`/`isStarred`/`isArchived` into these.
+ */
+export interface ChatConversation {
+  id: string;
+  title: string;
+  /** ISO 8601 string OR Date — surfaces differ; the sidebar normalizes both. */
+  updatedAt: string | Date;
+  pinned?: boolean;
+  archived?: boolean;
+  starred?: boolean;
+  projectId?: string | null;
+  /** Preview text of the last message. */
+  lastMessage?: string;
+  messageCount?: number;
+  /** Per-conversation model override — takes precedence over `selectedModelId`. */
+  modelOverride?: string;
+  /** When true, messages in this conversation are not persisted (desktop). */
+  incognito?: boolean;
+}
+
+/** Options for `createConversation`. */
+export interface CreateConversationOptions {
+  id?: string;
+  projectId?: string | null;
+  modelOverride?: string;
+  incognito?: boolean;
+  /** When true, the new conversation becomes the active one. Default: true. */
+  activate?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Transport port — the injected IO boundary
+// ---------------------------------------------------------------------------
+
+/**
+ * Parameters handed to the transport when sending a chat turn. The shared store
+ * does NOT interpret these beyond passing them through — each surface's port
+ * reads the fields it needs (web reads `model`/`webSearch`/`thinkingEnabled`
+ * to build the `/api/llm/v1/chat/completions` body; desktop reads them to build
+ * the `chat_send_message` Tauri invoke).
+ */
+export interface SendChatParams {
+  conversationId: string;
+  /** The id of the optimistic assistant placeholder message to stream into. */
+  assistantMessageId: string;
+  /** The user message text being sent. */
+  content: string;
+  /** Resolved model id (or auto-* alias). Never a hardcoded literal. */
+  model: string;
+  /** Full message history the surface wants to send to the model. */
+  messages: ChatMessage[];
+  webSearch?: boolean;
+  thinkingEnabled?: boolean;
+  codeExecution?: boolean;
+  /** Effort / reasoning level when the surface exposes it. */
+  effort?: string;
+  /** Arbitrary surface-specific extras (skillBody, styleMode, attachments…). */
+  extra?: Record<string, unknown>;
+  /** Abort signal so callers can cancel an in-flight stream. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Streaming callbacks the transport invokes as chunks arrive. These map 1:1
+ * onto the store's streaming actions so a surface port can simply forward each
+ * event to the store. The store wires concrete implementations of these (bound
+ * to `assistantMessageId`) when it calls `port.sendChat`.
+ */
+export interface SendChatCallbacks {
+  /** Append a content delta to the streaming assistant message. */
+  onContent: (chunk: string) => void;
+  /** Append an extended-thinking delta. */
+  onThinking: (chunk: string) => void;
+  /** Replace the full tool timeline for the message. */
+  onToolTimeline: (tools: ChatToolEntry[]) => void;
+  /** Patch a single tool entry by tool_call_id. */
+  onToolEntry: (toolCallId: string, patch: Partial<ChatToolEntry>) => void;
+  /** Toggle the "searching the web" indicator. */
+  onSearching: (isSearching: boolean) => void;
+  /** Attach web-search results. */
+  onSearchResults: (results: ChatSearchResult[]) => void;
+  /** Toggle the "executing code" indicator. */
+  onExecutingCode: (isExecuting: boolean) => void;
+  /** Attach a code-execution result. */
+  onCodeExecutionResult: (result: ChatCodeExecutionResult) => void;
+  /** Patch the assistant message itself (e.g. final model id, metadata). */
+  onMessagePatch: (patch: Partial<ChatMessage>) => void;
+  /** Terminal success — stream finished cleanly. */
+  onDone: () => void;
+  /** Terminal error — stream failed. */
+  onError: (message: string) => void;
+}
+
+/**
+ * The injected IO boundary. Each surface implements this against its own
+ * backend: web → `fetch('/api/llm/v1/chat/completions')` + `/api/chat/conversations`;
+ * desktop → Tauri `invoke('chat_send_message' | 'chat_get_conversations' | …)`.
+ *
+ * The store NEVER imports a transport directly — it is passed to `createChatStore`.
+ * All members are optional so a surface can wire only the slices it needs
+ * (e.g. a read-only or in-memory surface can omit remote CRUD and only provide
+ * `sendChat`).
+ */
+export interface ChatStorePort {
+  /** Load the conversation list from the system of record. */
+  loadConversations?: () => Promise<ChatConversation[]>;
+  /** Create a conversation server-side and return its canonical record. */
+  createRemoteConversation?: (title?: string) => Promise<ChatConversation>;
+  /** Load the messages for one conversation. */
+  loadConversationMessages?: (conversationId: string) => Promise<ChatMessage[]>;
+  /** Persist a single message (fire-and-forget on most surfaces). */
+  persistMessage?: (conversationId: string, message: ChatMessage) => Promise<void>;
+  /** Delete a conversation server-side. */
+  deleteRemoteConversation?: (conversationId: string) => Promise<void>;
+  /**
+   * Send a chat turn and stream the response back through `callbacks`.
+   * The promise resolves when the stream is fully consumed (or rejects on a
+   * transport-level failure the store will route to `setError`).
+   */
+  sendChat: (params: SendChatParams, callbacks: SendChatCallbacks) => Promise<void>;
+}

--- a/packages/stores/src/index.ts
+++ b/packages/stores/src/index.ts
@@ -2,15 +2,38 @@
  * @agiworkforce/stores
  *
  * Shared Zustand stores for the AGI Workforce platform.
- * Consumed by both desktop (Tauri) and web (Next.js) apps.
+ * Consumed by desktop (Tauri), web (Next.js), and mobile (Expo). All IO is
+ * injected via adapters so the stores stay pure (no next/, no tauri, no DOM).
  *
  * Stores are added incrementally as commands are wired in each wave.
  *
  * @packageDocumentation
  */
 
-// Stores will be exported here as they are created in subsequent waves.
+// ---------------------------------------------------------------------------
+// Chat store (platform-agnostic, transport-injected)
+// ---------------------------------------------------------------------------
+export { createChatStore } from './chat/chatStore';
+export type {
+  ChatStore,
+  ChatStoreState,
+  CreateChatStoreOptions,
+  SendUserMessageParams,
+} from './chat/chatStore';
+export type {
+  ChatMessage,
+  ChatConversation,
+  ChatToolEntry,
+  ChatToolStatus,
+  ChatSearchResult,
+  ChatCodeExecutionResult,
+  CreateConversationOptions,
+  ChatStorePort,
+  SendChatParams,
+  SendChatCallbacks,
+} from './chat/types';
+
+// Additional stores will be exported here as they are created in subsequent waves.
 // Example (Wave 1+):
-// export { useChatStore } from './chat/chatStore';
 // export { useSettingsStore } from './settingsStore';
 // export { useModelStore } from './modelStore';

--- a/packages/ui/src/cn.ts
+++ b/packages/ui/src/cn.ts
@@ -1,0 +1,20 @@
+/**
+ * Local className combiner for @agiworkforce/ui.
+ *
+ * packages/ui MUST NOT import a surface's `cn` (apps/desktop/lib/utils or
+ * @shared/lib/utils) — that would couple the shared package to a surface.
+ * This is a minimal, dependency-free join: it filters falsy values and
+ * collapses whitespace. It deliberately does NOT do Tailwind class merging
+ * (no tailwind-merge dependency) — callers pass non-conflicting classes, and
+ * the component's own classes come last so an explicit `className` override
+ * still wins via CSS source order.
+ */
+export type ClassValue = string | number | false | null | undefined;
+
+export function cn(...values: ClassValue[]): string {
+  return values
+    .filter((value): value is string | number => Boolean(value))
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -9,6 +9,35 @@
 
 export { ProviderMark, hasProviderMark } from './ProviderMark';
 export { AgiMark } from './AgiMark';
+export { cn } from './cn';
+export {
+  Sidebar,
+  type SidebarProps,
+  ProjectsView,
+  type ProjectsViewProps,
+  type ProjectViewProject,
+  type ProjectViewConversation,
+  type ProjectViewFile,
+  SessionItem,
+  type SessionItemProps,
+  type SessionItemHandlers,
+  SearchOverlay,
+  type SearchOverlayProps,
+  Menu,
+  MenuItem,
+  MenuSeparator,
+  type MenuProps,
+  type MenuItemProps,
+  getTemporalGroup,
+  TEMPORAL_LABELS,
+  toSafeDate,
+  type SidebarSession,
+  type SidebarProject,
+  type SidebarMode,
+  type SidebarTemporalGroup,
+  type SidebarNavItem,
+  type SidebarIconComponent,
+} from './sidebar';
 export {
   SETTINGS_NAV,
   SETTINGS_NAV_GROUPS,

--- a/packages/ui/src/sidebar/Menu.tsx
+++ b/packages/ui/src/sidebar/Menu.tsx
@@ -1,0 +1,134 @@
+/**
+ * Tiny headless dropdown menu — dependency-free replacement for the Radix
+ * DropdownMenu the desktop/web sidebars used. packages/ui must not pull Radix
+ * (it would bloat the pure-UI package and break its dependency budget), and a
+ * sidebar's 3-dots / project-filter menus are simple enough to own here.
+ *
+ * Behavior: click trigger to toggle; click outside or Escape to close; clicking
+ * an item runs its handler then closes. Positioned absolutely under (or above)
+ * the trigger. Styling uses the same hsl(var(--*)) tokens the surfaces resolve.
+ */
+import { useEffect, useRef, useState, type ReactNode, type CSSProperties } from 'react';
+import { cn } from '../cn';
+
+export interface MenuProps {
+  /** The clickable element that toggles the menu. */
+  trigger: (args: { open: boolean; toggle: () => void }) => ReactNode;
+  children: (args: { close: () => void }) => ReactNode;
+  align?: 'start' | 'end';
+  /** Open above the trigger instead of below. */
+  side?: 'top' | 'bottom';
+  className?: string;
+  menuClassName?: string;
+}
+
+export function Menu({
+  trigger,
+  children,
+  align = 'start',
+  side = 'bottom',
+  className,
+  menuClassName,
+}: MenuProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const close = () => setOpen(false);
+  const toggle = () => setOpen((v) => !v);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  const menuStyle: CSSProperties = {
+    [side === 'bottom' ? 'top' : 'bottom']: 'calc(100% + 4px)',
+    [align === 'start' ? 'left' : 'right']: 0,
+  };
+
+  return (
+    <div ref={containerRef} className={cn('relative', className)}>
+      {trigger({ open, toggle })}
+      {open && (
+        <div
+          role="menu"
+          style={menuStyle}
+          className={cn(
+            'absolute z-50 min-w-[12rem] overflow-hidden rounded-md border p-1 shadow-lg',
+            'border-[hsl(var(--border))] bg-[hsl(var(--popover))] text-[hsl(var(--popover-foreground))]',
+            menuClassName,
+          )}
+        >
+          {children({ close })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export interface MenuItemProps {
+  onSelect: () => void;
+  close: () => void;
+  icon?: ReactNode;
+  children: ReactNode;
+  /** Trailing content (count, shortcut). */
+  trailing?: ReactNode;
+  destructive?: boolean;
+  active?: boolean;
+  className?: string;
+}
+
+export function MenuItem({
+  onSelect,
+  close,
+  icon,
+  children,
+  trailing,
+  destructive,
+  active,
+  className,
+}: MenuItemProps) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={(e) => {
+        e.stopPropagation();
+        onSelect();
+        close();
+      }}
+      className={cn(
+        'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm transition-colors',
+        'hover:bg-[hsl(var(--accent))] focus-visible:bg-[hsl(var(--accent))] focus-visible:outline-none',
+        destructive ? 'text-red-500 hover:text-red-500' : 'text-[hsl(var(--popover-foreground))]',
+        active && 'bg-[hsl(var(--accent))]',
+        className,
+      )}
+    >
+      {icon && <span className="flex h-4 w-4 shrink-0 items-center justify-center">{icon}</span>}
+      <span className="flex-1 truncate">{children}</span>
+      {trailing && (
+        <span className="ml-auto shrink-0 text-xs text-[hsl(var(--muted-foreground))]">
+          {trailing}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export function MenuSeparator() {
+  return <div role="separator" className="my-1 h-px bg-[hsl(var(--border))]" />;
+}

--- a/packages/ui/src/sidebar/Menu.tsx
+++ b/packages/ui/src/sidebar/Menu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * Tiny headless dropdown menu — dependency-free replacement for the Radix
  * DropdownMenu the desktop/web sidebars used. packages/ui must not pull Radix

--- a/packages/ui/src/sidebar/ProjectsView.tsx
+++ b/packages/ui/src/sidebar/ProjectsView.tsx
@@ -1,0 +1,530 @@
+/**
+ * ProjectsView — the ChatGPT project-folders view (list + detail pane), ported
+ * from apps/desktop/src/features/chat/ProjectsView.tsx as pure presentation.
+ *
+ * Project DATA, linked conversations, knowledge files, and all mutations
+ * (create / open / new-chat / rename / delete / archive / select) are injected
+ * as props. NO store, NO IO, NO router. The desktop ProjectHeader /
+ * summarizeProjectHeader (which live in @agiworkforce/unified-chat) are NOT
+ * imported here to keep the pure-UI dependency budget — surfaces compose the
+ * header above this view if they want it.
+ */
+import { useMemo, useState } from 'react';
+import {
+  Brain,
+  ChevronRight,
+  File,
+  FolderOpen,
+  Layers,
+  MessageSquare,
+  MoreHorizontal,
+  Plus,
+  Search,
+  Settings,
+  Sparkles,
+  Trash2,
+  Archive,
+} from 'lucide-react';
+import { cn } from '../cn';
+import { Menu, MenuItem, MenuSeparator } from './Menu';
+import type { SidebarProject } from './types';
+
+/** A linked conversation chip in the project detail pane. */
+export interface ProjectViewConversation {
+  id: string;
+  title: string;
+}
+
+/** A file row in the project detail pane (project file or knowledge file). */
+export interface ProjectViewFile {
+  id: string;
+  name: string;
+  path?: string;
+  size?: number;
+}
+
+/** Extended project record the view renders in the detail pane. */
+export interface ProjectViewProject extends SidebarProject {
+  archived?: boolean;
+  customInstructions?: string;
+  conversations?: ProjectViewConversation[];
+  files?: ProjectViewFile[];
+  knowledgeFiles?: ProjectViewFile[];
+}
+
+export interface ProjectsViewProps {
+  projects: ProjectViewProject[];
+  selectedProjectId?: string | null;
+  isLoading?: boolean;
+  onSelectProject: (id: string) => void;
+  onCreateProject: () => void;
+  onOpenProject: (id: string) => void;
+  onNewChatInProject?: (id: string) => void;
+  onRenameProject?: (id: string) => void;
+  onOpenSettings?: (id: string) => void;
+  onDeleteProject: (id: string) => void;
+  onArchiveProject?: (id: string) => void;
+  onOpenConversation: (projectId: string, conversationId: string) => void;
+  className?: string;
+}
+
+export function ProjectsView({
+  projects,
+  selectedProjectId = null,
+  isLoading = false,
+  onSelectProject,
+  onCreateProject,
+  onOpenProject,
+  onNewChatInProject,
+  onRenameProject,
+  onOpenSettings,
+  onDeleteProject,
+  onArchiveProject,
+  onOpenConversation,
+  className,
+}: ProjectsViewProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filtered = useMemo(() => {
+    const term = searchQuery.trim().toLowerCase();
+    if (!term) return projects;
+    return projects.filter(
+      (p) =>
+        p.name.toLowerCase().includes(term) || (p.description ?? '').toLowerCase().includes(term),
+    );
+  }, [projects, searchQuery]);
+
+  const selected = selectedProjectId ? projects.find((p) => p.id === selectedProjectId) : null;
+
+  if (!isLoading && projects.length === 0) {
+    return (
+      <div
+        className={cn(
+          'flex h-full flex-col items-center justify-center bg-[hsl(var(--background))]/50 p-8 text-center',
+          className,
+        )}
+      >
+        <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] text-[hsl(var(--muted-foreground))]">
+          <Layers className="h-8 w-8" />
+        </div>
+        <h2 className="mb-3 text-2xl font-semibold tracking-tight text-[hsl(var(--foreground))]">
+          Keep related work together
+        </h2>
+        <p className="mb-6 max-w-md text-sm leading-6 text-[hsl(var(--muted-foreground))]">
+          Projects give AGI shared context across chats, files, instructions, and memory.
+        </p>
+        <button
+          type="button"
+          onClick={onCreateProject}
+          className="flex items-center gap-2 rounded-lg bg-[hsl(var(--foreground))] px-4 py-2 text-sm font-medium text-[hsl(var(--background))] transition-colors hover:bg-[hsl(var(--foreground))]/90"
+        >
+          <Plus className="h-4 w-4" />
+          Create project
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('flex h-full bg-[hsl(var(--background))]', className)}>
+      {/* Project list */}
+      <div className="flex w-80 flex-col border-r border-[hsl(var(--border))]">
+        <div className="border-b border-[hsl(var(--border))] p-4">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="flex items-center gap-2 text-lg font-semibold text-[hsl(var(--foreground))]">
+              <Layers className="h-5 w-5 text-blue-400" />
+              Projects
+            </h2>
+            <button
+              type="button"
+              onClick={onCreateProject}
+              aria-label="Create project"
+              className="flex h-8 w-8 items-center justify-center rounded-md bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))] transition-colors hover:bg-[hsl(var(--primary))]/90"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[hsl(var(--muted-foreground))]" />
+            <input
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search projects..."
+              className="w-full rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card))] py-2 pl-9 pr-3 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+            />
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          {isLoading ? (
+            <div className="p-4 text-center text-[hsl(var(--muted-foreground))]">
+              Loading projects...
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="p-4 text-center text-[hsl(var(--muted-foreground))]">
+              {searchQuery ? 'No projects match your search' : 'No projects found'}
+            </div>
+          ) : (
+            <div className="space-y-1 p-2">
+              {filtered.map((project) => (
+                <ProjectListItem
+                  key={project.id}
+                  project={project}
+                  isSelected={selectedProjectId === project.id}
+                  onClick={() => onSelectProject(project.id)}
+                  onOpen={() => onOpenProject(project.id)}
+                  onNewChat={onNewChatInProject ? () => onNewChatInProject(project.id) : undefined}
+                  onRename={onRenameProject ? () => onRenameProject(project.id) : undefined}
+                  onOpenSettings={onOpenSettings ? () => onOpenSettings(project.id) : undefined}
+                  onArchive={onArchiveProject ? () => onArchiveProject(project.id) : undefined}
+                  onDelete={() => onDeleteProject(project.id)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Detail pane */}
+      <div className="flex flex-1 flex-col">
+        {selected ? (
+          <ProjectDetails
+            project={selected}
+            onOpen={() => onOpenProject(selected.id)}
+            onOpenSettings={onOpenSettings ? () => onOpenSettings(selected.id) : undefined}
+            onOpenConversation={(conversationId) => onOpenConversation(selected.id, conversationId)}
+          />
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center text-[hsl(var(--muted-foreground))]">
+            <FolderOpen className="mb-4 h-16 w-16 opacity-30" />
+            <p>Select a project to view details</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface ProjectListItemProps {
+  project: ProjectViewProject;
+  isSelected: boolean;
+  onClick: () => void;
+  onOpen: () => void;
+  onNewChat?: () => void;
+  onRename?: () => void;
+  onOpenSettings?: () => void;
+  onArchive?: () => void;
+  onDelete: () => void;
+}
+
+function ProjectListItem({
+  project,
+  isSelected,
+  onClick,
+  onOpen,
+  onNewChat,
+  onRename,
+  onOpenSettings,
+  onArchive,
+  onDelete,
+}: ProjectListItemProps) {
+  return (
+    <div
+      onClick={onClick}
+      className={cn(
+        'group relative cursor-pointer rounded-lg p-3 transition-colors',
+        isSelected ? 'bg-[hsl(var(--muted))]' : 'hover:bg-[hsl(var(--accent))]/50',
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-lg"
+          style={{ backgroundColor: project.color || 'hsl(var(--primary))' }}
+        >
+          {project.iconEmoji ? (
+            <span>{project.iconEmoji}</span>
+          ) : (
+            <Layers className="h-5 w-5 text-white" />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate text-sm font-medium text-[hsl(var(--foreground))]">
+              {project.name}
+            </h3>
+            {project.archived && (
+              <span className="rounded-full bg-[hsl(var(--accent))] px-1.5 py-0.5 text-[10px] text-[hsl(var(--muted-foreground))]">
+                Archived
+              </span>
+            )}
+          </div>
+          <p className="mt-0.5 truncate text-xs text-[hsl(var(--muted-foreground))]">
+            {project.description || 'No description'}
+          </p>
+          <div className="mt-1.5 flex items-center gap-3 text-xs text-[hsl(var(--muted-foreground))]">
+            <span className="flex items-center gap-1">
+              <MessageSquare className="h-3 w-3" />
+              {project.conversations?.length ?? project.conversationCount ?? 0}
+            </span>
+            <span className="flex items-center gap-1">
+              <File className="h-3 w-3" />
+              {project.files?.length ?? 0}
+            </span>
+          </div>
+        </div>
+
+        <Menu
+          align="end"
+          trigger={({ toggle }) => (
+            <button
+              type="button"
+              aria-label="Project actions"
+              onClick={(e) => {
+                e.stopPropagation();
+                toggle();
+              }}
+              className="flex h-8 w-8 items-center justify-center rounded-md text-[hsl(var(--muted-foreground))] opacity-0 transition-opacity hover:bg-[hsl(var(--accent))] group-hover:opacity-100"
+            >
+              <MoreHorizontal className="h-4 w-4" />
+            </button>
+          )}
+        >
+          {({ close }) => (
+            <>
+              <MenuItem close={close} onSelect={onOpen} icon={<FolderOpen className="h-4 w-4" />}>
+                Open Project
+              </MenuItem>
+              {onNewChat && (
+                <MenuItem close={close} onSelect={onNewChat} icon={<Plus className="h-4 w-4" />}>
+                  New chat
+                </MenuItem>
+              )}
+              {onRename && (
+                <MenuItem close={close} onSelect={onRename} icon={<File className="h-4 w-4" />}>
+                  Rename
+                </MenuItem>
+              )}
+              {onOpenSettings && (
+                <MenuItem
+                  close={close}
+                  onSelect={onOpenSettings}
+                  icon={<Settings className="h-4 w-4" />}
+                >
+                  Project Settings
+                </MenuItem>
+              )}
+              <MenuSeparator />
+              {onArchive && (
+                <MenuItem close={close} onSelect={onArchive} icon={<Archive className="h-4 w-4" />}>
+                  {project.archived ? 'Unarchive' : 'Archive'}
+                </MenuItem>
+              )}
+              <MenuItem
+                close={close}
+                onSelect={onDelete}
+                icon={<Trash2 className="h-4 w-4" />}
+                destructive
+              >
+                Delete
+              </MenuItem>
+            </>
+          )}
+        </Menu>
+      </div>
+    </div>
+  );
+}
+
+interface ProjectDetailsProps {
+  project: ProjectViewProject;
+  onOpen: () => void;
+  onOpenSettings?: () => void;
+  onOpenConversation: (conversationId: string) => void;
+}
+
+function ProjectDetails({
+  project,
+  onOpen,
+  onOpenSettings,
+  onOpenConversation,
+}: ProjectDetailsProps) {
+  const conversations = project.conversations ?? [];
+  const files = project.files ?? [];
+  const knowledgeFiles = project.knowledgeFiles ?? [];
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="border-b border-[hsl(var(--border))] p-6">
+        <div className="flex items-start gap-4">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-3">
+              <div
+                className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl text-xl"
+                style={{ backgroundColor: project.color || 'hsl(var(--primary))' }}
+              >
+                {project.iconEmoji ? (
+                  <span>{project.iconEmoji}</span>
+                ) : (
+                  <Layers className="h-6 w-6 text-white" />
+                )}
+              </div>
+              <div className="min-w-0">
+                <h1 className="truncate text-xl font-semibold text-[hsl(var(--foreground))]">
+                  {project.name}
+                </h1>
+                {project.description && (
+                  <p className="truncate text-sm text-[hsl(var(--muted-foreground))]">
+                    {project.description}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="flex shrink-0 gap-2">
+            {onOpenSettings && (
+              <button
+                type="button"
+                onClick={onOpenSettings}
+                className="flex items-center gap-2 rounded-lg border border-[hsl(var(--border))] px-3 py-2 text-sm text-[hsl(var(--foreground))] transition-colors hover:bg-[hsl(var(--accent))]"
+              >
+                <Settings className="h-4 w-4" />
+                Settings
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onOpen}
+              className="flex items-center gap-2 rounded-lg bg-[hsl(var(--primary))] px-3 py-2 text-sm text-[hsl(var(--primary-foreground))] transition-colors hover:bg-[hsl(var(--primary))]/90"
+            >
+              <FolderOpen className="h-4 w-4" />
+              Open Project
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-6 p-6">
+        <div className="col-span-2 grid gap-4 md:grid-cols-3">
+          {[
+            {
+              label: 'Conversations',
+              value: conversations.length,
+              icon: MessageSquare,
+              tone: 'text-blue-400',
+            },
+            { label: 'Project Files', value: files.length, icon: File, tone: 'text-green-400' },
+            {
+              label: 'Knowledge Files',
+              value: knowledgeFiles.length,
+              icon: Brain,
+              tone: 'text-purple-400',
+            },
+          ].map((item) => (
+            <div
+              key={item.label}
+              className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-4"
+            >
+              <div className="flex items-center gap-2 text-sm text-[hsl(var(--muted-foreground))]">
+                <item.icon className={cn('h-4 w-4', item.tone)} />
+                <span>{item.label}</span>
+              </div>
+              <div className="mt-2 text-2xl font-semibold text-[hsl(var(--foreground))]">
+                {item.value}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Custom instructions */}
+        <div className="col-span-2 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-4">
+          <h3 className="mb-2 flex items-center gap-2 text-sm font-medium text-[hsl(var(--foreground))]">
+            <Sparkles className="h-4 w-4 text-amber-500" />
+            Custom Instructions
+          </h3>
+          {project.customInstructions ? (
+            <pre className="max-h-40 overflow-auto whitespace-pre-wrap rounded bg-[hsl(var(--background))] p-3 font-mono text-sm text-[hsl(var(--muted-foreground))]">
+              {project.customInstructions}
+            </pre>
+          ) : (
+            <p className="text-sm italic text-[hsl(var(--muted-foreground))]">
+              No custom instructions set
+            </p>
+          )}
+        </div>
+
+        {/* Linked conversations */}
+        <div className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-4">
+          <h3 className="mb-3 flex items-center gap-2 text-sm font-medium text-[hsl(var(--foreground))]">
+            <MessageSquare className="h-4 w-4 text-blue-400" />
+            Linked Conversations
+            <span className="ml-auto rounded-full bg-[hsl(var(--muted))] px-2 py-0.5 text-xs text-[hsl(var(--muted-foreground))]">
+              {conversations.length}
+            </span>
+          </h3>
+          {conversations.length > 0 ? (
+            <div className="max-h-60 space-y-2 overflow-auto">
+              {conversations.map((conv) => (
+                <button
+                  type="button"
+                  key={conv.id}
+                  onClick={() => onOpenConversation(conv.id)}
+                  className="flex w-full items-center gap-2 rounded-md bg-[hsl(var(--muted))] p-2 text-sm transition-colors hover:bg-[hsl(var(--accent))]/80"
+                >
+                  <MessageSquare className="h-4 w-4 text-[hsl(var(--muted-foreground))]" />
+                  <span className="truncate text-[hsl(var(--foreground))]">
+                    {conv.title || 'Untitled Conversation'}
+                  </span>
+                  <ChevronRight className="ml-auto h-4 w-4 text-[hsl(var(--muted-foreground))]" />
+                </button>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm italic text-[hsl(var(--muted-foreground))]">
+              No conversations linked yet
+            </p>
+          )}
+        </div>
+
+        {/* Knowledge base */}
+        <div className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-4">
+          <h3 className="mb-3 flex items-center gap-2 text-sm font-medium text-[hsl(var(--foreground))]">
+            <Brain className="h-4 w-4 text-purple-400" />
+            Knowledge Base
+            <span className="ml-auto rounded-full bg-[hsl(var(--muted))] px-2 py-0.5 text-xs text-[hsl(var(--muted-foreground))]">
+              {knowledgeFiles.length}
+            </span>
+          </h3>
+          {knowledgeFiles.length > 0 ? (
+            <div className="max-h-60 space-y-2 overflow-auto">
+              {knowledgeFiles.map((file) => (
+                <div
+                  key={file.id}
+                  className="flex items-center gap-2 rounded-md bg-[hsl(var(--muted))] p-2 text-sm"
+                >
+                  <Brain className="h-4 w-4 text-[hsl(var(--muted-foreground))]" />
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-[hsl(var(--foreground))]">{file.name}</div>
+                    {file.path && (
+                      <div className="truncate text-xs text-[hsl(var(--muted-foreground))]">
+                        {file.path}
+                      </div>
+                    )}
+                  </div>
+                  {file.size != null && (
+                    <span className="text-xs text-[hsl(var(--muted-foreground))]">
+                      {(file.size / 1024).toFixed(0)} KB
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm italic text-[hsl(var(--muted-foreground))]">
+              No knowledge base files added yet
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/sidebar/ProjectsView.tsx
+++ b/packages/ui/src/sidebar/ProjectsView.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * ProjectsView — the ChatGPT project-folders view (list + detail pane), ported
  * from apps/desktop/src/features/chat/ProjectsView.tsx as pure presentation.

--- a/packages/ui/src/sidebar/SearchOverlay.tsx
+++ b/packages/ui/src/sidebar/SearchOverlay.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * SearchOverlay — the centered command-palette-style search modal the desktop
  * Sidebar opens. Pure presentation: results + handlers are passed in. Uses a

--- a/packages/ui/src/sidebar/SearchOverlay.tsx
+++ b/packages/ui/src/sidebar/SearchOverlay.tsx
@@ -1,0 +1,110 @@
+/**
+ * SearchOverlay — the centered command-palette-style search modal the desktop
+ * Sidebar opens. Pure presentation: results + handlers are passed in. Uses a
+ * CSS fade (no framer-motion) and a plain backdrop. Escape/backdrop close.
+ */
+import { useEffect, useRef } from 'react';
+import { Search } from 'lucide-react';
+import { cn } from '../cn';
+import type { SidebarSession } from './types';
+
+export interface SearchOverlayProps {
+  open: boolean;
+  query: string;
+  onQueryChange: (value: string) => void;
+  results: SidebarSession[];
+  activeSessionId?: string;
+  onSelect: (id: string) => void;
+  onClose: () => void;
+}
+
+export function SearchOverlay({
+  open,
+  query,
+  onQueryChange,
+  results,
+  activeSessionId,
+  onSelect,
+  onClose,
+}: SearchOverlayProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
+      onClick={onClose}
+      data-state="open"
+    >
+      <div
+        className="fixed left-1/2 top-1/2 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 px-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="overflow-hidden rounded-xl bg-[hsl(var(--card))] shadow-2xl">
+          <div className="flex items-center gap-3 border-b border-[hsl(var(--border))] px-5 py-4">
+            <Search className="h-5 w-5 text-[hsl(var(--muted-foreground))]" />
+            <input
+              ref={inputRef}
+              placeholder="Search conversations..."
+              value={query}
+              onChange={(e) => onQueryChange(e.target.value)}
+              className="flex-1 bg-transparent text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:outline-none"
+            />
+            <kbd className="rounded bg-[hsl(var(--muted))] px-2 py-1 text-xs text-[hsl(var(--muted-foreground))]">
+              ESC
+            </kbd>
+          </div>
+          <div className="max-h-96 overflow-y-auto p-2">
+            {results.length === 0 ? (
+              <div className="px-3 py-8 text-center text-sm text-[hsl(var(--muted-foreground))]">
+                No conversations found
+              </div>
+            ) : (
+              results.slice(0, 10).map((conv) => (
+                <button
+                  type="button"
+                  key={conv.id}
+                  onClick={() => {
+                    onSelect(conv.id);
+                    onClose();
+                  }}
+                  className={cn(
+                    'w-full rounded-lg px-3 py-2 text-left transition-colors',
+                    conv.id === activeSessionId
+                      ? 'bg-[hsl(var(--primary))]/10'
+                      : 'hover:bg-[hsl(var(--accent))]',
+                  )}
+                >
+                  <div className="text-sm font-medium text-[hsl(var(--foreground))]">
+                    {conv.title || 'Untitled'}
+                  </div>
+                  {(conv.lastMessage ?? conv.preview) && (
+                    <div className="mt-1 truncate text-xs text-[hsl(var(--muted-foreground))]">
+                      {conv.lastMessage ?? conv.preview}
+                    </div>
+                  )}
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/sidebar/SessionItem.tsx
+++ b/packages/ui/src/sidebar/SessionItem.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * SessionItem — a single conversation row, ChatGPT-style: title + preview,
  * active highlight, inline-rename, and a hover 3-dots menu exposing pin/star/

--- a/packages/ui/src/sidebar/SessionItem.tsx
+++ b/packages/ui/src/sidebar/SessionItem.tsx
@@ -1,0 +1,286 @@
+/**
+ * SessionItem — a single conversation row, ChatGPT-style: title + preview,
+ * active highlight, inline-rename, and a hover 3-dots menu exposing pin/star/
+ * rename/share/archive/move-to-project/delete. Ported from the desktop
+ * ConversationItem hover-action layout + the web ConversationListItem menu,
+ * merged into one prop-driven, store-free component.
+ *
+ * Every action is an injected callback; the component performs NO IO.
+ */
+import { memo, useEffect, useRef, useState } from 'react';
+import {
+  Archive,
+  ArchiveRestore,
+  Folder,
+  Link2,
+  MoreHorizontal,
+  Pencil,
+  Pin,
+  PinOff,
+  Sparkles,
+  Star,
+  Trash2,
+} from 'lucide-react';
+import { cn } from '../cn';
+import { Menu, MenuItem, MenuSeparator } from './Menu';
+import type { SidebarProject, SidebarSession } from './types';
+
+export interface SessionItemHandlers {
+  onSelect: (id: string) => void;
+  onRename: (id: string, title: string) => void;
+  onDelete: (id: string) => void;
+  onTogglePin?: (id: string) => void;
+  onStar?: (id: string) => void;
+  onArchive?: (id: string) => void;
+  onRestore?: (id: string) => void;
+  onShare?: (id: string) => void;
+  onMoveToProject?: (id: string, projectId: string) => void;
+  onOpenCustomInstructions?: (id: string) => void;
+}
+
+export interface SessionItemProps extends SessionItemHandlers {
+  session: SidebarSession;
+  isActive: boolean;
+  isKeyboardFocused?: boolean;
+  /** When set, shows a "in <name>" attribution line under the preview. */
+  projectName?: string;
+  /** Projects offered in the "Move to project" submenu. */
+  projects?: SidebarProject[];
+  /** Compact menu (delete only) — mirrors desktop Simple Mode. */
+  simple?: boolean;
+}
+
+function SessionItemBase({
+  session,
+  isActive,
+  isKeyboardFocused = false,
+  projectName,
+  projects,
+  simple = false,
+  onSelect,
+  onRename,
+  onDelete,
+  onTogglePin,
+  onStar,
+  onArchive,
+  onRestore,
+  onShare,
+  onMoveToProject,
+  onOpenCustomInstructions,
+}: SessionItemProps) {
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState(session.title);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isRenaming && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isRenaming]);
+
+  const submitRename = () => {
+    const next = renameValue.trim();
+    if (next && next !== session.title) {
+      onRename(session.id, next);
+    }
+    setIsRenaming(false);
+  };
+
+  const preview = session.lastMessage ?? session.preview;
+
+  if (isRenaming) {
+    return (
+      <div className="mb-1 rounded-lg px-2 py-1.5">
+        <input
+          ref={inputRef}
+          value={renameValue}
+          onChange={(e) => setRenameValue(e.target.value)}
+          onBlur={submitRename}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') submitRename();
+            if (e.key === 'Escape') setIsRenaming(false);
+          }}
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            'w-full rounded-md border bg-[hsl(var(--background))] px-2 py-1 text-sm',
+            'border-[hsl(var(--border))] text-[hsl(var(--foreground))]',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]',
+          )}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'group relative mb-1 rounded-lg transition-colors',
+        isActive ? 'bg-[hsl(var(--accent))]' : 'hover:bg-[hsl(var(--accent))]',
+        isKeyboardFocused && 'ring-2 ring-[hsl(var(--ring))] ring-offset-1',
+        session.incognito && 'ring-1 ring-purple-500/20',
+      )}
+    >
+      <div className="flex items-center">
+        <button
+          type="button"
+          onClick={() => onSelect(session.id)}
+          onDoubleClick={() => setIsRenaming(true)}
+          aria-current={isActive ? 'page' : undefined}
+          className="min-w-0 flex-1 overflow-hidden px-3 py-2 text-left"
+        >
+          <div className="flex items-center gap-1.5">
+            {session.starred && <Star className="h-3 w-3 shrink-0 fill-amber-400 text-amber-400" />}
+            <span className="truncate text-sm font-medium text-[hsl(var(--foreground))]">
+              {session.title || 'Untitled'}
+            </span>
+          </div>
+          {preview && (
+            <div className="truncate text-xs text-[hsl(var(--muted-foreground))]">{preview}</div>
+          )}
+          {projectName && (
+            <div className="mt-0.5 truncate text-[10px] text-[hsl(var(--muted-foreground))]">
+              in <span className="font-medium text-[hsl(var(--foreground))]/60">{projectName}</span>
+            </div>
+          )}
+        </button>
+
+        <div className="flex items-center gap-0.5 pr-1.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+          {session.hasCustomInstructions && onOpenCustomInstructions && (
+            <button
+              type="button"
+              title="Custom instructions"
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpenCustomInstructions(session.id);
+              }}
+              className="flex h-6 w-6 items-center justify-center rounded-md text-amber-500 hover:bg-[hsl(var(--muted))]"
+            >
+              <Sparkles className="h-3 w-3" />
+            </button>
+          )}
+          <Menu
+            align="end"
+            trigger={({ toggle }) => (
+              <button
+                type="button"
+                title="More actions"
+                aria-label="Conversation actions"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggle();
+                }}
+                className="flex h-6 w-6 items-center justify-center rounded-md text-[hsl(var(--muted-foreground))] hover:bg-[hsl(var(--muted))] hover:text-[hsl(var(--foreground))]"
+              >
+                <MoreHorizontal className="h-3.5 w-3.5" />
+              </button>
+            )}
+          >
+            {({ close }) => (
+              <>
+                {!simple && onTogglePin && (
+                  <MenuItem
+                    close={close}
+                    onSelect={() => onTogglePin(session.id)}
+                    icon={
+                      session.pinned ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />
+                    }
+                  >
+                    {session.pinned ? 'Unpin' : 'Pin'}
+                  </MenuItem>
+                )}
+                {!simple && onStar && (
+                  <MenuItem
+                    close={close}
+                    onSelect={() => onStar(session.id)}
+                    icon={<Star className="h-4 w-4" />}
+                  >
+                    {session.starred ? 'Unstar' : 'Star'}
+                  </MenuItem>
+                )}
+                {!simple && (
+                  <MenuItem
+                    close={close}
+                    onSelect={() => setIsRenaming(true)}
+                    icon={<Pencil className="h-4 w-4" />}
+                  >
+                    Rename
+                  </MenuItem>
+                )}
+                {!simple && onShare && (
+                  <MenuItem
+                    close={close}
+                    onSelect={() => onShare(session.id)}
+                    icon={<Link2 className="h-4 w-4" />}
+                  >
+                    Share
+                  </MenuItem>
+                )}
+                {!simple && onMoveToProject && projects && projects.length > 0 && (
+                  <>
+                    <MenuSeparator />
+                    <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-[hsl(var(--muted-foreground))]">
+                      Move to project
+                    </div>
+                    {projects.map((project) => (
+                      <MenuItem
+                        key={project.id}
+                        close={close}
+                        onSelect={() => onMoveToProject(session.id, project.id)}
+                        icon={
+                          project.iconEmoji ? (
+                            <span className="text-sm leading-none">{project.iconEmoji}</span>
+                          ) : (
+                            <Folder className="h-4 w-4" />
+                          )
+                        }
+                        active={session.projectId === project.id}
+                      >
+                        {project.name}
+                      </MenuItem>
+                    ))}
+                  </>
+                )}
+                {!simple && (onArchive || onRestore) && (
+                  <>
+                    <MenuSeparator />
+                    {session.archived
+                      ? onRestore && (
+                          <MenuItem
+                            close={close}
+                            onSelect={() => onRestore(session.id)}
+                            icon={<ArchiveRestore className="h-4 w-4" />}
+                          >
+                            Restore
+                          </MenuItem>
+                        )
+                      : onArchive && (
+                          <MenuItem
+                            close={close}
+                            onSelect={() => onArchive(session.id)}
+                            icon={<Archive className="h-4 w-4" />}
+                          >
+                            Archive
+                          </MenuItem>
+                        )}
+                  </>
+                )}
+                <MenuItem
+                  close={close}
+                  onSelect={() => onDelete(session.id)}
+                  icon={<Trash2 className="h-4 w-4" />}
+                  destructive
+                >
+                  Delete
+                </MenuItem>
+              </>
+            )}
+          </Menu>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const SessionItem = memo(SessionItemBase);
+SessionItem.displayName = 'SessionItem';

--- a/packages/ui/src/sidebar/Sidebar.tsx
+++ b/packages/ui/src/sidebar/Sidebar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * <Sidebar> — the framework-agnostic chat sidebar shared by AGI Desktop and
  * AGI Web. Design ported faithfully from

--- a/packages/ui/src/sidebar/Sidebar.tsx
+++ b/packages/ui/src/sidebar/Sidebar.tsx
@@ -1,0 +1,664 @@
+/**
+ * <Sidebar> — the framework-agnostic chat sidebar shared by AGI Desktop and
+ * AGI Web. Design ported faithfully from
+ * apps/desktop/src/features/chat/Sidebar.tsx (+ ProjectsView / web ChatSidebar):
+ *
+ *   • ChatGPT-style new-chat / search header + compose affordance
+ *   • project-folder filter dropdown (ChatGPT project folders)
+ *   • pinned section + temporal grouping (Today / Yesterday / This Week / …)
+ *   • archive toggle, per-conversation hover 3-dots actions
+ *   • collapsed icon-rail
+ *   • footer with local/cloud mode pill + optional usage widget + footerSlot
+ *
+ * BOUNDARY: pure presentation. NO next/navigation, NO @tauri-apps, NO zustand,
+ * NO clerk, NO fetch. ALL data + handlers + surface-specific chrome are props.
+ * Navigation is done by the surface inside the injected handlers; surface
+ * chrome (account menu, notifications, incognito toggle) goes in `footerSlot`.
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Archive,
+  Calendar,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  FolderOpen,
+  Layers,
+  MessageSquare,
+  PanelLeft,
+  Pin,
+  Plus,
+  Search,
+  Sparkles,
+  X,
+} from 'lucide-react';
+import { cn } from '../cn';
+import { Menu, MenuItem, MenuSeparator } from './Menu';
+import { SearchOverlay } from './SearchOverlay';
+import { SessionItem, type SessionItemHandlers } from './SessionItem';
+import { getTemporalGroup, TEMPORAL_LABELS, toSafeDate } from './temporal';
+import type {
+  SidebarMode,
+  SidebarNavItem,
+  SidebarProject,
+  SidebarSession,
+  SidebarTemporalGroup,
+} from './types';
+
+export interface SidebarProps extends SessionItemHandlers {
+  /* ---- data ---- */
+  sessions: SidebarSession[];
+  activeSessionId?: string;
+  projects?: SidebarProject[];
+  selectedProjectFilter?: string | null;
+
+  /* ---- layout ---- */
+  className?: string;
+  collapsed?: boolean;
+  width?: number;
+  isMobile?: boolean;
+  /** Desktop "Simple Mode": collapses per-row actions to delete only. */
+  isSimpleMode?: boolean;
+
+  /* ---- footer ---- */
+  mode?: SidebarMode;
+  budgetPercent?: number;
+  showUsageWidget?: boolean;
+
+  /* ---- handlers (data/IO injected by the surface) ---- */
+  onNewChat: () => void;
+  onToggleCollapse?: () => void;
+  onSelectProjectFilter?: (projectId: string | null) => void;
+  onOpenSearch?: () => void;
+  onOpenProjects?: () => void;
+  onOpenSkills?: () => void;
+  onModeClick?: () => void;
+  onOpenUsage?: () => void;
+
+  /* ---- slots / render props for non-pure chrome ---- */
+  /** Extra nav rows (desktop puts Projects/Skills; web puts Chats/Artifacts/…). */
+  navItems?: SidebarNavItem[];
+  /** Renders a nav item — defaults to a <button onClick>. Surface can return next/<Link>. */
+  renderNavLink?: (item: SidebarNavItem) => React.ReactNode;
+  /** Below the list, above the footer — e.g. a Free-plan nudge. */
+  navExtraSlot?: React.ReactNode;
+  /** Footer chrome: desktop = UserProfile+NotificationCenter+IncognitoToggle; web = UserProfileArea. */
+  footerSlot?: React.ReactNode;
+  /** Header chrome injected next to the new-chat button (desktop incognito toggle). */
+  headerSlot?: React.ReactNode;
+}
+
+const DEFAULT_EXPANDED: SidebarTemporalGroup[] = ['today', 'yesterday', 'thisWeek'];
+
+export function Sidebar(props: SidebarProps) {
+  const {
+    sessions,
+    activeSessionId,
+    projects = [],
+    selectedProjectFilter = null,
+    className,
+    collapsed = false,
+    width = 260,
+    // isMobile is part of the public API (surfaces collapse on mobile inside
+    // their own onSelect/onNewChat handlers); the component itself is layout-only.
+    isMobile: _isMobile = false,
+    isSimpleMode = false,
+    mode = 'local',
+    budgetPercent = 0,
+    showUsageWidget = false,
+    onNewChat,
+    onToggleCollapse,
+    onSelectProjectFilter,
+    onOpenSearch,
+    onOpenProjects,
+    onOpenSkills,
+    onModeClick,
+    onOpenUsage,
+    navItems,
+    renderNavLink,
+    navExtraSlot,
+    footerSlot,
+    headerSlot,
+    // SessionItem handlers
+    onSelect,
+    onRename,
+    onDelete,
+    onTogglePin,
+    onStar,
+    onArchive,
+    onRestore,
+    onShare,
+    onMoveToProject,
+    onOpenCustomInstructions,
+  } = props;
+
+  const modKeySymbol =
+    typeof navigator !== 'undefined' && navigator.platform.includes('Mac') ? '⌘' : 'Ctrl';
+
+  const [internalSearchOpen, setInternalSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showArchived, setShowArchived] = useState(false);
+  const [expandedGroups, setExpandedGroups] = useState<Set<SidebarTemporalGroup>>(
+    new Set(DEFAULT_EXPANDED),
+  );
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+
+  // Surface can override the search overlay entirely (web uses GlobalSearchDialog).
+  const handleOpenSearch = useCallback(() => {
+    if (onOpenSearch) onOpenSearch();
+    else setInternalSearchOpen(true);
+  }, [onOpenSearch]);
+
+  const projectNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    projects.forEach((p) => map.set(p.id, p.name));
+    return map;
+  }, [projects]);
+
+  const selectedProject = useMemo(
+    () => (selectedProjectFilter ? projects.find((p) => p.id === selectedProjectFilter) : null),
+    [projects, selectedProjectFilter],
+  );
+
+  const archivedCount = useMemo(
+    () => sessions.filter((s) => s.archived === true).length,
+    [sessions],
+  );
+
+  const filtered = useMemo(() => {
+    const term = searchQuery.trim().toLowerCase();
+    let base = showArchived
+      ? sessions.filter((s) => s.archived === true)
+      : sessions.filter((s) => !s.archived);
+    if (selectedProjectFilter) {
+      base = base.filter((s) => s.projectId === selectedProjectFilter);
+    }
+    if (!term) return base;
+    return base.filter((s) =>
+      `${s.title ?? ''} ${s.lastMessage ?? s.preview ?? ''}`.toLowerCase().includes(term),
+    );
+  }, [sessions, searchQuery, showArchived, selectedProjectFilter]);
+
+  const pinned = useMemo(
+    () =>
+      filtered
+        .filter((s) => s.pinned)
+        .sort((a, b) => toSafeDate(b.updatedAt).getTime() - toSafeDate(a.updatedAt).getTime()),
+    [filtered],
+  );
+
+  const grouped = useMemo(() => {
+    const groups = new Map<SidebarTemporalGroup, SidebarSession[]>();
+    filtered
+      .filter((s) => !s.pinned)
+      .forEach((s) => {
+        const group = getTemporalGroup(toSafeDate(s.updatedAt));
+        if (!groups.has(group)) groups.set(group, []);
+        groups.get(group)!.push(s);
+      });
+    groups.forEach((arr) =>
+      arr.sort((a, b) => toSafeDate(b.updatedAt).getTime() - toSafeDate(a.updatedAt).getTime()),
+    );
+    return groups;
+  }, [filtered]);
+
+  const visible = useMemo(() => {
+    const out: SidebarSession[] = [...pinned];
+    grouped.forEach((arr, group) => {
+      if (expandedGroups.has(group)) out.push(...arr);
+    });
+    return out;
+  }, [pinned, grouped, expandedGroups]);
+
+  const toggleGroup = useCallback((group: SidebarTemporalGroup) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(group)) next.delete(group);
+      else next.add(group);
+      return next;
+    });
+  }, []);
+
+  // Keyboard arrow navigation over the visible list (ported from desktop).
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+        return;
+      }
+      if (internalSearchOpen) return;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setFocusedIndex((p) => (p + 1 >= visible.length ? 0 : p + 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setFocusedIndex((p) => (p - 1 < 0 ? visible.length - 1 : p - 1));
+      } else if (e.key === 'Enter' && focusedIndex >= 0) {
+        e.preventDefault();
+        const conv = visible[focusedIndex];
+        if (conv) {
+          onSelect(conv.id);
+          setFocusedIndex(-1);
+        }
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [internalSearchOpen, visible, focusedIndex, onSelect]);
+
+  const renderSessionRow = useCallback(
+    (session: SidebarSession) => {
+      const globalIndex = visible.findIndex((c) => c.id === session.id);
+      return (
+        <SessionItem
+          key={session.id}
+          session={session}
+          isActive={session.id === activeSessionId}
+          isKeyboardFocused={globalIndex === focusedIndex}
+          projectName={session.projectId ? projectNameById.get(session.projectId) : undefined}
+          projects={projects}
+          simple={isSimpleMode}
+          onSelect={onSelect}
+          onRename={onRename}
+          onDelete={onDelete}
+          onTogglePin={onTogglePin}
+          onStar={onStar}
+          onArchive={onArchive}
+          onRestore={onRestore}
+          onShare={onShare}
+          onMoveToProject={onMoveToProject}
+          onOpenCustomInstructions={onOpenCustomInstructions}
+        />
+      );
+    },
+    [
+      visible,
+      activeSessionId,
+      focusedIndex,
+      projectNameById,
+      projects,
+      isSimpleMode,
+      onSelect,
+      onRename,
+      onDelete,
+      onTogglePin,
+      onStar,
+      onArchive,
+      onRestore,
+      onShare,
+      onMoveToProject,
+      onOpenCustomInstructions,
+    ],
+  );
+
+  const defaultRenderNavLink = useCallback((item: SidebarNavItem) => {
+    const Icon = item.icon;
+    return (
+      <button
+        key={item.id}
+        type="button"
+        onClick={item.onClick}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]',
+          item.isActive
+            ? 'bg-[hsl(var(--accent))] text-[hsl(var(--foreground))]'
+            : 'text-[hsl(var(--muted-foreground))] hover:bg-[hsl(var(--accent))] hover:text-[hsl(var(--foreground))]',
+        )}
+      >
+        <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+        <span className="flex-1 text-left">{item.label}</span>
+        {item.badge != null && (
+          <span className="text-xs text-[hsl(var(--muted-foreground))]">{item.badge}</span>
+        )}
+      </button>
+    );
+  }, []);
+
+  const resolvedNavItems = useMemo<SidebarNavItem[]>(() => {
+    if (navItems) return navItems;
+    const items: SidebarNavItem[] = [];
+    if (onOpenProjects) {
+      items.push({ id: 'projects', label: 'Projects', icon: FolderOpen, onClick: onOpenProjects });
+    }
+    if (onOpenSkills) {
+      items.push({ id: 'skills', label: 'Skills', icon: Sparkles, onClick: onOpenSkills });
+    }
+    return items;
+  }, [navItems, onOpenProjects, onOpenSkills]);
+
+  /* ---------------- collapsed icon-rail ---------------- */
+  if (collapsed) {
+    return (
+      <div className="flex w-16 flex-col border-r border-[hsl(var(--border))] bg-[hsl(var(--card))] transition-all duration-300 ease-in-out">
+        <div className="flex flex-col items-center gap-4 p-3">
+          <RailButton label="Expand sidebar" icon={PanelLeft} onClick={onToggleCollapse} />
+          <RailButton label="New chat" icon={Plus} onClick={onNewChat} />
+          <RailButton label="Search" icon={Search} onClick={handleOpenSearch} />
+          {onOpenProjects && (
+            <RailButton label="Projects" icon={FolderOpen} onClick={onOpenProjects} />
+          )}
+          {onOpenSkills && <RailButton label="Skills" icon={Sparkles} onClick={onOpenSkills} />}
+          <div
+            title={mode === 'local' ? 'Local' : 'Cloud'}
+            className={cn(
+              'h-2 w-2 rounded-full',
+              mode === 'local' ? 'bg-emerald-400' : 'bg-blue-400',
+            )}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  /* ---------------- expanded sidebar ---------------- */
+  return (
+    <>
+      {!onOpenSearch && (
+        <SearchOverlay
+          open={internalSearchOpen}
+          query={searchQuery}
+          onQueryChange={setSearchQuery}
+          results={filtered}
+          activeSessionId={activeSessionId}
+          onSelect={onSelect}
+          onClose={() => {
+            setInternalSearchOpen(false);
+            setSearchQuery('');
+          }}
+        />
+      )}
+
+      <div
+        className={cn(
+          'relative flex flex-col border-r border-[hsl(var(--border))] bg-[hsl(var(--card))] transition-all duration-300 ease-in-out',
+          className,
+        )}
+        style={{ width }}
+      >
+        {/* Header: collapse + compose + search */}
+        <div className="border-b border-[hsl(var(--border))] p-4">
+          <div className="mb-3 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={onToggleCollapse}
+              aria-label="Collapse sidebar"
+              className="flex h-8 w-8 items-center justify-center rounded-md text-[hsl(var(--muted-foreground))] hover:bg-[hsl(var(--accent))] hover:text-[hsl(var(--foreground))]"
+            >
+              <PanelLeft className="h-4 w-4" />
+            </button>
+            <div className="flex items-center gap-1.5">
+              {headerSlot}
+              <button
+                type="button"
+                onClick={onNewChat}
+                aria-label="New chat"
+                className="flex items-center gap-2 rounded-lg bg-[hsl(var(--muted))] px-3 py-1.5 text-sm font-medium text-[hsl(var(--foreground))] transition-colors hover:bg-[hsl(var(--accent))]"
+              >
+                <Plus className="h-4 w-4" />
+                New Chat
+              </button>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={handleOpenSearch}
+            className="flex w-full items-center gap-2 rounded-lg bg-[hsl(var(--muted))] px-3 py-2 text-sm text-[hsl(var(--foreground))] transition-colors hover:bg-[hsl(var(--accent))]"
+          >
+            <Search className="h-4 w-4" />
+            <span>Search</span>
+            <span className="ml-auto flex items-center gap-1">
+              <kbd className="rounded bg-[hsl(var(--card))] px-1.5 py-0.5 text-xs">
+                {modKeySymbol}
+              </kbd>
+              <kbd className="rounded bg-[hsl(var(--card))] px-1.5 py-0.5 text-xs">K</kbd>
+            </span>
+          </button>
+        </div>
+
+        {/* Nav rows (Projects / Skills / surface-provided) */}
+        {!isSimpleMode && resolvedNavItems.length > 0 && (
+          <div className="space-y-0.5 border-b border-[hsl(var(--border))] px-2 py-1.5">
+            {resolvedNavItems.map((item) => (renderNavLink ?? defaultRenderNavLink)(item))}
+          </div>
+        )}
+
+        {/* Filter bar: project folder filter + archive toggle */}
+        {!isSimpleMode && (projects.length > 0 || archivedCount > 0) && (
+          <div className="flex items-center gap-1 px-3 py-2">
+            {projects.length > 0 && (
+              <Menu
+                align="start"
+                trigger={({ toggle }) => (
+                  <button
+                    type="button"
+                    onClick={toggle}
+                    className={cn(
+                      'flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors',
+                      selectedProjectFilter
+                        ? 'bg-blue-500/10 text-blue-600 dark:text-blue-400'
+                        : 'text-[hsl(var(--muted-foreground))] hover:bg-[hsl(var(--accent))]',
+                    )}
+                  >
+                    <span
+                      className="flex h-4 w-4 items-center justify-center rounded"
+                      style={
+                        selectedProject?.color
+                          ? {
+                              backgroundColor: `${selectedProject.color}20`,
+                              color: selectedProject.color,
+                            }
+                          : undefined
+                      }
+                    >
+                      <FolderOpen className="h-3 w-3" />
+                    </span>
+                    <span className="max-w-[100px] truncate">{selectedProject?.name || 'All'}</span>
+                    <ChevronDown className="h-3 w-3 text-[hsl(var(--muted-foreground))]" />
+                  </button>
+                )}
+                menuClassName="w-56"
+              >
+                {({ close }) => (
+                  <>
+                    <MenuItem
+                      close={close}
+                      onSelect={() => onSelectProjectFilter?.(null)}
+                      icon={<MessageSquare className="h-4 w-4" />}
+                      active={!selectedProjectFilter}
+                    >
+                      All Conversations
+                    </MenuItem>
+                    <MenuSeparator />
+                    {projects.map((project) => (
+                      <MenuItem
+                        key={project.id}
+                        close={close}
+                        onSelect={() => onSelectProjectFilter?.(project.id)}
+                        active={selectedProjectFilter === project.id}
+                        trailing={project.conversationCount}
+                        icon={
+                          <span
+                            className="flex h-4 w-4 items-center justify-center rounded"
+                            style={{ backgroundColor: project.color || 'hsl(var(--primary))' }}
+                          >
+                            <Layers className="h-2.5 w-2.5 text-white" />
+                          </span>
+                        }
+                      >
+                        {project.name}
+                      </MenuItem>
+                    ))}
+                  </>
+                )}
+              </Menu>
+            )}
+
+            {selectedProjectFilter && onSelectProjectFilter && (
+              <button
+                type="button"
+                onClick={() => onSelectProjectFilter(null)}
+                aria-label="Clear filter"
+                title="Clear filter"
+                className="flex h-7 w-7 items-center justify-center rounded-md text-[hsl(var(--muted-foreground))] hover:text-[hsl(var(--foreground))]"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
+
+            <div className="flex-1" />
+
+            {archivedCount > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowArchived((v) => !v)}
+                title={showArchived ? 'Show active' : `Archived (${archivedCount})`}
+                className={cn(
+                  'flex h-7 w-7 items-center justify-center rounded-md transition-colors',
+                  showArchived
+                    ? 'text-amber-600 dark:text-amber-400'
+                    : 'text-[hsl(var(--muted-foreground))] hover:text-[hsl(var(--foreground))]',
+                )}
+              >
+                <Archive className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Conversation list */}
+        <div className="flex-1 overflow-y-auto">
+          <div className="p-2">
+            {pinned.length > 0 && (
+              <div className="mb-6">
+                <div className="mb-2 flex items-center gap-1 px-3 text-xs font-semibold uppercase tracking-wider text-[hsl(var(--muted-foreground))]">
+                  <Pin className="h-3 w-3" /> Pinned
+                </div>
+                {pinned.map(renderSessionRow)}
+              </div>
+            )}
+
+            {Array.from(grouped.entries()).map(([group, convs]) => {
+              const isExpanded = expandedGroups.has(group);
+              return (
+                <div key={group} className="mb-4">
+                  <button
+                    type="button"
+                    onClick={() => toggleGroup(group)}
+                    aria-expanded={isExpanded}
+                    className="flex w-full items-center gap-2 px-2 py-1 text-xs font-medium text-[hsl(var(--muted-foreground))] transition-colors hover:text-[hsl(var(--foreground))]"
+                  >
+                    <ChevronRight
+                      className={cn('h-3 w-3 transition-transform', isExpanded && 'rotate-90')}
+                    />
+                    <span className="flex items-center gap-1">
+                      {group === 'today' && <Calendar className="h-3 w-3" />}
+                      {group === 'yesterday' && <Clock className="h-3 w-3" />}
+                      {TEMPORAL_LABELS[group]}
+                    </span>
+                    <span className="ml-auto text-[hsl(var(--muted-foreground))]">
+                      ({convs.length})
+                    </span>
+                  </button>
+                  {isExpanded && (
+                    <div className="mt-1 space-y-1">{convs.map(renderSessionRow)}</div>
+                  )}
+                </div>
+              );
+            })}
+
+            {visible.length === 0 && (
+              <div className="flex flex-col items-center justify-center px-4 py-12 text-center">
+                <MessageSquare className="mb-2 h-7 w-7 text-[hsl(var(--muted-foreground))]/30" />
+                <p className="text-sm text-[hsl(var(--muted-foreground))]/60">
+                  {showArchived ? 'No archived conversations' : 'No conversations yet'}
+                </p>
+                {!showArchived && (
+                  <button
+                    type="button"
+                    onClick={onNewChat}
+                    className="mt-2 text-xs text-[hsl(var(--primary))] hover:underline"
+                  >
+                    Start a new chat
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Extra slot above footer (e.g. free-plan nudge) */}
+        {navExtraSlot}
+
+        {/* Footer: usage widget + mode pill + injected chrome */}
+        <div className="mt-auto space-y-2 border-t border-[hsl(var(--border))] px-3 py-2.5">
+          {showUsageWidget && (
+            <button
+              type="button"
+              onClick={onOpenUsage}
+              title={`${Math.round(budgetPercent)}% of token budget used`}
+              className="group flex w-full items-center gap-2 rounded-md px-1 py-1 transition-colors hover:bg-[hsl(var(--accent))]"
+            >
+              <div className="h-1 flex-1 overflow-hidden rounded-full bg-[hsl(var(--muted))]">
+                <div
+                  className={cn(
+                    'h-full rounded-full transition-all duration-300',
+                    budgetPercent >= 95
+                      ? 'bg-red-500'
+                      : budgetPercent >= 80
+                        ? 'bg-amber-500'
+                        : 'bg-blue-500',
+                  )}
+                  style={{ width: `${Math.min(Math.max(budgetPercent, 0), 100)}%` }}
+                />
+              </div>
+              <span className="shrink-0 text-[10px] tabular-nums text-[hsl(var(--muted-foreground))]">
+                {Math.round(budgetPercent)}%
+              </span>
+            </button>
+          )}
+          <div className="flex items-center gap-1.5 overflow-hidden">
+            <div className="min-w-0 flex-1 overflow-hidden">{footerSlot}</div>
+            {onModeClick && (
+              <button
+                type="button"
+                onClick={onModeClick}
+                title={mode === 'local' ? 'Local mode' : 'Cloud mode'}
+                className={cn(
+                  'shrink-0 cursor-pointer rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider transition-colors',
+                  mode === 'local'
+                    ? 'bg-emerald-500/20 text-emerald-500 hover:bg-emerald-500/30'
+                    : 'bg-blue-500/20 text-blue-500 hover:bg-blue-500/30',
+                )}
+              >
+                {mode === 'local' ? 'Local' : 'Cloud'}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function RailButton({
+  label,
+  icon: Icon,
+  onClick,
+}: {
+  label: string;
+  icon: SidebarNavItem['icon'];
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+      className="flex h-9 w-9 items-center justify-center rounded-lg text-[hsl(var(--muted-foreground))] transition-colors hover:bg-[hsl(var(--accent))] hover:text-[hsl(var(--foreground))]"
+    >
+      <Icon className="h-4 w-4" />
+    </button>
+  );
+}

--- a/packages/ui/src/sidebar/index.ts
+++ b/packages/ui/src/sidebar/index.ts
@@ -1,0 +1,20 @@
+export { Sidebar, type SidebarProps } from './Sidebar';
+export {
+  ProjectsView,
+  type ProjectsViewProps,
+  type ProjectViewProject,
+  type ProjectViewConversation,
+  type ProjectViewFile,
+} from './ProjectsView';
+export { SessionItem, type SessionItemProps, type SessionItemHandlers } from './SessionItem';
+export { SearchOverlay, type SearchOverlayProps } from './SearchOverlay';
+export { Menu, MenuItem, MenuSeparator, type MenuProps, type MenuItemProps } from './Menu';
+export { getTemporalGroup, TEMPORAL_LABELS, toSafeDate } from './temporal';
+export type {
+  SidebarSession,
+  SidebarProject,
+  SidebarMode,
+  SidebarTemporalGroup,
+  SidebarNavItem,
+  SidebarIconComponent,
+} from './types';

--- a/packages/ui/src/sidebar/temporal.ts
+++ b/packages/ui/src/sidebar/temporal.ts
@@ -1,0 +1,50 @@
+import type { SidebarTemporalGroup } from './types';
+
+export const TEMPORAL_LABELS: Record<SidebarTemporalGroup, string> = {
+  today: 'Today',
+  yesterday: 'Yesterday',
+  thisWeek: 'This Week',
+  last7Days: 'Last 7 Days',
+  last30Days: 'Last 30 Days',
+  older: 'Older',
+};
+
+/** Ported verbatim from apps/desktop/src/features/chat/Sidebar.tsx getTemporalGroup. */
+export function getTemporalGroup(date: Date): SidebarTemporalGroup {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const thisWeekStart = new Date(today);
+  thisWeekStart.setDate(thisWeekStart.getDate() - today.getDay());
+  const sevenDaysAgo = new Date(today);
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+  const thirtyDaysAgo = new Date(today);
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+  const conversationDate = new Date(date);
+
+  if (conversationDate >= today) {
+    return 'today';
+  } else if (conversationDate >= yesterday && conversationDate < today) {
+    return 'yesterday';
+  } else if (conversationDate >= thisWeekStart && conversationDate < yesterday) {
+    return 'thisWeek';
+  } else if (conversationDate >= sevenDaysAgo) {
+    return 'last7Days';
+  } else if (conversationDate >= thirtyDaysAgo) {
+    return 'last30Days';
+  } else {
+    return 'older';
+  }
+}
+
+/** Coerce a Date|string into a safe Date (epoch on invalid input). */
+export function toSafeDate(raw: Date | string | undefined): Date {
+  if (raw instanceof Date) {
+    return Number.isNaN(raw.getTime()) ? new Date(0) : raw;
+  }
+  if (!raw) return new Date(0);
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? new Date(0) : d;
+}

--- a/packages/ui/src/sidebar/types.ts
+++ b/packages/ui/src/sidebar/types.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared <Sidebar> contracts.
+ *
+ * These types are the framework-agnostic shape the chat sidebar renders. They
+ * normalize the desktop `ConversationSummary` (pinned/archived/projectId/
+ * incognito) and the web `SessionLike` (isPinned/isStarred/isArchived) into a
+ * single field set so neither surface loses pin/archive/star/project-filter
+ * behavior. Surfaces map their store records into `SidebarSession` /
+ * `SidebarProject` before passing them in.
+ *
+ * NO store, IO, router, or platform import lives here — pure data contracts.
+ */
+import type { ReactNode } from 'react';
+
+/** A conversation row in the sidebar list. */
+export interface SidebarSession {
+  id: string;
+  title: string;
+  /** ISO string or Date — the component normalizes both for temporal grouping. */
+  updatedAt: Date | string;
+  /** Secondary preview line under the title. `preview` is the web alias of `lastMessage`. */
+  lastMessage?: string;
+  preview?: string;
+  pinned?: boolean;
+  starred?: boolean;
+  archived?: boolean;
+  /** Project this conversation belongs to (drives the attribution badge + filter). */
+  projectId?: string;
+  /** Incognito conversations get a subtle accent ring; never persisted by the component. */
+  incognito?: boolean;
+  messageCount?: number;
+  /** When set, a small Sparkles affordance highlights that custom instructions exist. */
+  hasCustomInstructions?: boolean;
+}
+
+/** A ChatGPT-style project folder shown in the filter dropdown + projects view. */
+export interface SidebarProject {
+  id: string;
+  name: string;
+  /** Hex or CSS color used for the folder swatch. */
+  color?: string;
+  accentColor?: string;
+  iconEmoji?: string;
+  description?: string;
+  conversationCount?: number;
+}
+
+/** Footer mode pill state. Local = on-device; Cloud = AGI managed. */
+export type SidebarMode = 'local' | 'cloud';
+
+/** Temporal grouping buckets used by `getTemporalGroup`. */
+export type SidebarTemporalGroup =
+  | 'today'
+  | 'yesterday'
+  | 'thisWeek'
+  | 'last7Days'
+  | 'last30Days'
+  | 'older';
+
+/**
+ * Descriptor passed to `renderNavLink` so neither next/<Link> nor router.push
+ * leaks into the shared package. The default renderer is a `<button onClick>`.
+ */
+export interface SidebarNavItem {
+  id: string;
+  label: string;
+  /** lucide icon component (or any icon component accepting `className`). */
+  icon: SidebarIconComponent;
+  onClick: () => void;
+  isActive?: boolean;
+  /** Optional trailing badge text (e.g. a count). */
+  badge?: string | number;
+}
+
+/** Minimal icon-component shape — matches a lucide-react icon. */
+export type SidebarIconComponent = (props: {
+  className?: string;
+  'aria-hidden'?: boolean | 'true' | 'false';
+}) => ReactNode;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -634,61 +634,61 @@ importers:
         version: link:../../packages/utils
       '@clerk/expo':
         specifier: ^3.4.2
-        version: 3.4.2(lgupmayksuc3hqb7k77g7dzcxa)
+        version: 3.4.2(tcpsy7udqgz6qidljwbr3q4g2m)
       '@expo/metro-runtime':
         specifier: ~55.0.11
-        version: 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       '@gorhom/bottom-sheet':
         specifier: ^5.1.2
-        version: 5.2.8(x5iawplkmjw3ewnw2hxzkobmbm)
+        version: 5.2.8(polr62kqbobf542oxhaehs4ahq)
       '@kingstinct/react-native-healthkit':
         specifier: ^6.0.0
-        version: 6.1.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 6.1.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       '@noble/hashes':
         specifier: ^1.8.0
         version: 1.8.0
       '@react-native-community/netinfo':
         specifier: ^11.5.2
-        version: 11.5.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 11.5.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       '@react-native-community/slider':
         specifier: ^5.1.2
         version: 5.1.2
       '@react-navigation/drawer':
         specifier: ^7.9.4
-        version: 7.9.6(qwrsk7whjxbzfhkagqa7vqfdpu)
+        version: 7.9.6(5cjugtjgehekxhv4zj5ab4jqii)
       '@react-navigation/native':
         specifier: ^7.1.33
-        version: 7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       '@shopify/flash-list':
         specifier: 2.0.2
-        version: 2.0.2(@babel/runtime@7.29.2)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 2.0.2(@babel/runtime@7.29.2)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo:
         specifier: ~55.0.23
-        version: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+        version: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       expo-apple-authentication:
         specifier: ~55.0.13
-        version: 55.0.13(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+        version: 55.0.13(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       expo-asset:
         specifier: ~55.0.17
-        version: 55.0.17(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)
+        version: 55.0.17(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)
       expo-background-fetch:
         specifier: ~55.0.15
-        version: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+        version: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       expo-calendar:
         specifier: ~55.0.14
-        version: 55.0.14(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+        version: 55.0.14(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       expo-camera:
         specifier: ~55.0.18
-        version: 55.0.18(@types/emscripten@1.41.5)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 55.0.18(@types/emscripten@1.41.5)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo-clipboard:
         specifier: ~55.0.13
-        version: 55.0.13(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 55.0.13(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo-constants:
         specifier: ~55.0.16
-        version: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+        version: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       expo-contacts:
         specifier: ~55.0.14
-        version: 55.0.14(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 55.0.14(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo-crypto:
         specifier: ~55.0.14
         version: 55.0.15(expo@55.0.24)
@@ -697,19 +697,19 @@ importers:
         version: 55.0.13(expo@55.0.24)
       expo-file-system:
         specifier: ~55.0.20
-        version: 55.0.20(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+        version: 55.0.20(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       expo-haptics:
         specifier: ~55.0.14
         version: 55.0.14(expo@55.0.24)
       expo-image:
         specifier: ~55.0.10
-        version: 55.0.10(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 55.0.10(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo-image-picker:
         specifier: ~55.0.20
         version: 55.0.20(expo@55.0.24)
       expo-linking:
         specifier: ~55.0.15
-        version: 55.0.15(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 55.0.15(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo-local-authentication:
         specifier: ~55.0.13
         version: 55.0.14(expo@55.0.24)
@@ -718,88 +718,88 @@ importers:
         version: 55.0.15(expo@55.0.24)(react@19.2.6)
       expo-notifications:
         specifier: ~55.0.22
-        version: 55.0.23(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)
+        version: 55.0.23(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)
       expo-print:
         specifier: ~55.0.14
-        version: 55.0.15(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+        version: 55.0.15(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       expo-router:
         specifier: ~55.0.14
-        version: 55.0.14(n4bhh46ocnqckxeacbx7tz5z2q)
+        version: 55.0.14(g6uw2d3pskkivjko2jfnh74tr4)
       expo-secure-store:
         specifier: ~55.0.13
         version: 55.0.14(expo@55.0.24)
       expo-sharing:
         specifier: ~55.0.18
-        version: 55.0.19(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 55.0.19(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo-speech:
         specifier: ~55.0.13
         version: 55.0.14(expo@55.0.24)
       expo-speech-recognition:
         specifier: ^3.1.3
-        version: 3.1.3(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 3.1.3(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo-splash-screen:
         specifier: ~55.0.20
         version: 55.0.21(expo@55.0.24)(typescript@5.9.3)
       expo-sqlite:
         specifier: ~55.0.16
-        version: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo-status-bar:
         specifier: ~55.0.6
-        version: 55.0.6(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 55.0.6(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo-task-manager:
         specifier: ~55.0.15
-        version: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+        version: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       expo-updates:
         specifier: ~55.0.21
-        version: 55.0.22(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 55.0.22(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo-web-browser:
         specifier: ~55.0.15
-        version: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+        version: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       llama.rn:
         specifier: ^0.10.0
-        version: 0.10.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 0.10.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       lucide-react-native:
         specifier: ^0.577.0
-        version: 0.577.0(react-native-svg@15.15.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 0.577.0(react-native-svg@15.15.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       nativewind:
         specifier: ^4.2.3
-        version: 4.2.3(4n25dg5g6d76yfbhsmprwdwrty)
+        version: 4.2.3(dqaevcjldhvzporyuwciexzmmm)
       react:
         specifier: 19.2.6
         version: 19.2.6
       react-native:
         specifier: 0.83.6
-        version: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+        version: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       react-native-executorch:
         specifier: ^0.8.4
-        version: 0.8.4(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 0.8.4(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       react-native-executorch-expo-resource-fetcher:
         specifier: ^0.8.0
-        version: 0.8.0(pfkl2nycxdmijgx66zi7jxoftu)
+        version: 0.8.0(expo-asset@55.0.17(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3))(expo-file-system@55.0.20(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)))(expo@55.0.24)(react-native-executorch@0.8.4(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       react-native-gesture-handler:
         specifier: ~2.30.0
-        version: 2.30.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 2.30.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       react-native-mmkv:
         specifier: ^3.2.0
-        version: 3.3.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 3.3.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       react-native-reanimated:
         specifier: 4.3.1
-        version: 4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       react-native-safe-area-context:
         specifier: ~5.6.2
-        version: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       react-native-screens:
         specifier: ~4.23.0
-        version: 4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       react-native-svg:
         specifier: 15.15.3
-        version: 15.15.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 15.15.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       react-native-webrtc:
         specifier: ^124.0.5
-        version: 124.0.7(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+        version: 124.0.7(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       react-native-webview:
         specifier: 13.16.0
-        version: 13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
@@ -809,7 +809,7 @@ importers:
         version: 7.29.0
       '@testing-library/react-native':
         specifier: ^13.3.3
-        version: 13.3.3(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react-test-renderer@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 13.3.3(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react-test-renderer@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -824,10 +824,10 @@ importers:
         version: 29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)
       jest-expo:
         specifier: ~55.0.17
-        version: 55.0.17(@babel/core@7.29.0)(bufferutil@4.1.0)(expo@55.0.24)(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        version: 55.0.17(@babel/core@7.29.0)(bufferutil@4.1.0)(expo@55.0.24)(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react-native-worklets:
         specifier: 0.8.0
-        version: 0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+        version: 0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       react-test-renderer:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -1320,11 +1320,11 @@ importers:
         version: link:../types
       react-native:
         specifier: '>=0.83.0 <0.84.0'
-        version: 0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+        version: 0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     devDependencies:
       '@types/react-native':
         specifier: ^0.73.0
-        version: 0.73.0(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+        version: 0.73.0(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -1548,6 +1548,9 @@ importers:
       '@agiworkforce/types':
         specifier: workspace:*
         version: link:../types
+      '@agiworkforce/unified-chat':
+        specifier: workspace:*
+        version: link:../unified-chat
       immer:
         specifier: ^11.1.4
         version: 11.1.4
@@ -15290,13 +15293,13 @@ snapshots:
       - react
       - react-dom
 
-  '@clerk/clerk-js@6.16.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(immer@11.1.4)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.6))(utf-8-validate@6.0.6)(zod@4.4.3)':
+  '@clerk/clerk-js@6.16.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(immer@11.1.4)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.6))(utf-8-validate@6.0.6)(zod@4.4.3)':
     dependencies:
       '@base-org/account': 2.0.1(@types/react@19.2.14)(bufferutil@4.1.0)(immer@11.1.4)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.6))(utf-8-validate@6.0.6)(zod@4.4.3)
       '@clerk/shared': 4.17.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@coinbase/wallet-sdk': 4.3.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
-      '@solana/wallet-adapter-react': 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/wallet-adapter-react': 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/wallet-standard': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(react@19.2.6)
       '@stripe/stripe-js': 5.6.0
       '@swc/helpers': 0.5.21
@@ -15324,24 +15327,24 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@clerk/expo@3.4.2(lgupmayksuc3hqb7k77g7dzcxa)':
+  '@clerk/expo@3.4.2(tcpsy7udqgz6qidljwbr3q4g2m)':
     dependencies:
-      '@clerk/clerk-js': 6.16.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(immer@11.1.4)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.6))(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@clerk/clerk-js': 6.16.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(immer@11.1.4)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.6))(utf-8-validate@6.0.6)(zod@4.4.3)
       '@clerk/react': 6.9.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/shared': 4.17.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       base-64: 1.0.0
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
-      react-native-url-polyfill: 2.0.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native-url-polyfill: 2.0.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       tslib: 2.8.1
     optionalDependencies:
-      expo-apple-authentication: 55.0.13(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
-      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+      expo-apple-authentication: 55.0.13(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       expo-crypto: 55.0.15(expo@55.0.24)
       expo-local-authentication: 55.0.14(expo@55.0.24)
       expo-secure-store: 55.0.14(expo@55.0.24)
-      expo-web-browser: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+      expo-web-browser: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - '@solana/web3.js'
@@ -15778,7 +15781,7 @@ snapshots:
 
   '@expo-google-fonts/material-symbols@0.4.27': {}
 
-  '@expo/cli@55.0.30(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-constants@55.0.16)(expo-font@55.0.7)(expo-router@55.0.14)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@expo/cli@55.0.30(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-constants@55.0.16)(expo-font@55.0.7)(expo-router@55.0.14)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 55.0.17(typescript@5.9.3)
@@ -15787,7 +15790,7 @@ snapshots:
       '@expo/env': 2.1.2
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
       '@expo/json-file': 10.0.14
-      '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       '@expo/metro': 55.1.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@expo/metro-config': 55.0.21(bufferutil@4.1.0)(expo@55.0.24)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@expo/osascript': 2.4.3
@@ -15812,7 +15815,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3(supports-color@8.1.1)
       dnssd-advertise: 1.1.4
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       expo-server: 55.0.9
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -15839,8 +15842,8 @@ snapshots:
       ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 4.4.3
     optionalDependencies:
-      expo-router: 55.0.14(n4bhh46ocnqckxeacbx7tz5z2q)
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      expo-router: 55.0.14(g6uw2d3pskkivjko2jfnh74tr4)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@expo/dom-webview'
       - '@expo/metro-runtime'
@@ -15917,18 +15920,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/devtools@55.0.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
+  '@expo/devtools@55.0.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
       chalk: 4.1.2
     optionalDependencies:
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
-  '@expo/dom-webview@55.0.6(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
+  '@expo/dom-webview@55.0.6(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
   '@expo/env@2.1.2':
     dependencies:
@@ -15980,13 +15983,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/log-box@55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
+  '@expo/log-box@55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
-      '@expo/dom-webview': 55.0.6(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@expo/dom-webview': 55.0.6(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       anser: 1.4.10
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       stacktrace-parser: 0.1.11
 
   '@expo/metro-config@55.0.21(bufferutil@4.1.0)(expo@55.0.24)(typescript@5.9.3)(utf-8-validate@6.0.6)':
@@ -16011,21 +16014,21 @@ snapshots:
       postcss: 8.5.13
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@expo/metro-runtime@55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
+  '@expo/metro-runtime@55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
-      '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       anser: 1.4.10
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       pretty-format: 29.7.0
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
     optionalDependencies:
@@ -16082,7 +16085,7 @@ snapshots:
       '@expo/json-file': 10.0.14
       '@react-native/normalize-colors': 0.83.6
       debug: 4.4.3(supports-color@8.1.1)
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -16103,14 +16106,14 @@ snapshots:
   '@expo/router-server@55.0.16(@expo/metro-runtime@55.0.11)(expo-constants@55.0.16)(expo-font@55.0.7)(expo-router@55.0.14)(expo-server@55.0.9)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
-      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
-      expo-font: 55.0.7(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+      expo-font: 55.0.7(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo-server: 55.0.9
       react: 19.2.6
     optionalDependencies:
-      '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      expo-router: 55.0.14(n4bhh46ocnqckxeacbx7tz5z2q)
+      '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      expo-router: 55.0.14(g6uw2d3pskkivjko2jfnh74tr4)
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
@@ -16125,11 +16128,11 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
-  '@expo/vector-icons@15.1.1(expo-font@55.0.7)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
+  '@expo/vector-icons@15.1.1(expo-font@55.0.7)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
-      expo-font: 55.0.7(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      expo-font: 55.0.7(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
   '@expo/ws-tunnel@1.0.6': {}
 
@@ -16156,23 +16159,23 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@gorhom/bottom-sheet@5.2.8(x5iawplkmjw3ewnw2hxzkobmbm)':
+  '@gorhom/bottom-sheet@5.2.8(polr62kqbobf542oxhaehs4ahq)':
     dependencies:
-      '@gorhom/portal': 1.0.14(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@gorhom/portal': 1.0.14(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       invariant: 2.2.4
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
-      react-native-gesture-handler: 2.30.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native-gesture-handler: 2.30.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-native': 0.73.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      '@types/react-native': 0.73.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
-  '@gorhom/portal@1.0.14(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
+  '@gorhom/portal@1.0.14(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
       nanoid: 3.3.11
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
   '@hono/node-server@1.19.14(hono@4.12.21)':
     dependencies:
@@ -16579,10 +16582,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kingstinct/react-native-healthkit@6.1.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
+  '@kingstinct/react-native-healthkit@6.1.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
   '@mermaid-js/parser@1.1.1':
     dependencies:
@@ -17490,16 +17493,16 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@react-native-async-storage/async-storage@1.24.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))':
+  '@react-native-async-storage/async-storage@1.24.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))':
     dependencies:
       merge-options: 3.0.4
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     optional: true
 
-  '@react-native-community/netinfo@11.5.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
+  '@react-native-community/netinfo@11.5.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
   '@react-native-community/slider@5.1.2': {}
 
@@ -17698,7 +17701,7 @@ snapshots:
       yargs: 17.7.2
     optional: true
 
-  '@react-native/community-cli-plugin@0.83.6(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@react-native/community-cli-plugin@0.83.6(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@react-native/dev-middleware': 0.83.6(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       debug: 4.4.3(supports-color@8.1.1)
@@ -17708,13 +17711,13 @@ snapshots:
       metro-core: 0.83.7
       semver: 7.7.4
     optionalDependencies:
-      '@react-native/metro-config': 0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@react-native/metro-config': 0.85.3(@babel/core@7.29.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@react-native/community-cli-plugin@0.83.6(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@react-native/community-cli-plugin@0.83.6(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@react-native/dev-middleware': 0.83.6(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       debug: 4.4.3(supports-color@8.1.1)
@@ -17724,7 +17727,7 @@ snapshots:
       metro-core: 0.83.7
       semver: 7.7.4
     optionalDependencies:
-      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)
+      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -17781,7 +17784,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@react-native/metro-config@0.85.3(@babel/core@7.29.0)':
     dependencies:
       '@react-native/js-polyfills': 0.85.3
       '@react-native/metro-babel-transformer': 0.85.3(@babel/core@7.29.0)
@@ -17789,11 +17792,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
-  '@react-native/metro-config@0.85.3(@babel/core@7.29.7)':
+  '@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@react-native/js-polyfills': 0.85.3
       '@react-native/metro-babel-transformer': 0.85.3(@babel/core@7.29.7)
@@ -17801,38 +17802,40 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.83.6': {}
 
-  '@react-native/virtualized-lists@0.83.6(@types/react@19.2.14)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
+  '@react-native/virtualized-lists@0.83.6(@types/react@19.2.14)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@react-native/virtualized-lists@0.83.6(@types/react@19.2.14)(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
+  '@react-native/virtualized-lists@0.83.6(@types/react@19.2.14)(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@react-navigation/bottom-tabs@7.15.7(j4qkvs7upklbniepmc76d4ynk4)':
+  '@react-navigation/bottom-tabs@7.15.7(@react-navigation/native@7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-safe-area-context@5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-screens@4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
-      '@react-navigation/elements': 2.9.12(@react-navigation/native@7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-safe-area-context@5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      '@react-navigation/native': 7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@react-navigation/elements': 2.9.12(@react-navigation/native@7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-safe-area-context@5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@react-navigation/native': 7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       color: 4.2.3
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
-      react-native-safe-area-context: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-screens: 4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-screens: 4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       sf-symbols-typescript: 2.2.0
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
@@ -17849,54 +17852,54 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.2.6)
       use-sync-external-store: 1.6.0(react@19.2.6)
 
-  '@react-navigation/drawer@7.9.6(qwrsk7whjxbzfhkagqa7vqfdpu)':
+  '@react-navigation/drawer@7.9.6(5cjugtjgehekxhv4zj5ab4jqii)':
     dependencies:
-      '@react-navigation/elements': 2.9.12(@react-navigation/native@7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-safe-area-context@5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      '@react-navigation/native': 7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@react-navigation/elements': 2.9.12(@react-navigation/native@7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-safe-area-context@5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@react-navigation/native': 7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       color: 4.2.3
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
-      react-native-drawer-layout: 4.2.2(3qthecrptfltn7nk7tqaurr7uq)
-      react-native-gesture-handler: 2.30.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-safe-area-context: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-screens: 4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native-drawer-layout: 4.2.2(react-native-gesture-handler@2.30.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-reanimated@4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-gesture-handler: 2.30.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-screens: 4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       use-latest-callback: 0.2.6(react@19.2.6)
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
-  '@react-navigation/elements@2.9.12(@react-navigation/native@7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-safe-area-context@5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
+  '@react-navigation/elements@2.9.12(@react-navigation/native@7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-safe-area-context@5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
-      '@react-navigation/native': 7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@react-navigation/native': 7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       color: 4.2.3
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
-      react-native-safe-area-context: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       use-latest-callback: 0.2.6(react@19.2.6)
       use-sync-external-store: 1.6.0(react@19.2.6)
 
-  '@react-navigation/native-stack@7.14.7(j4qkvs7upklbniepmc76d4ynk4)':
+  '@react-navigation/native-stack@7.14.7(@react-navigation/native@7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-safe-area-context@5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-screens@4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
-      '@react-navigation/elements': 2.9.12(@react-navigation/native@7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-safe-area-context@5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      '@react-navigation/native': 7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@react-navigation/elements': 2.9.12(@react-navigation/native@7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-safe-area-context@5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@react-navigation/native': 7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       color: 4.2.3
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
-      react-native-safe-area-context: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-screens: 4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-screens: 4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       sf-symbols-typescript: 2.2.0
       warn-once: 0.1.1
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
-  '@react-navigation/native@7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
+  '@react-navigation/native@7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
       '@react-navigation/core': 7.17.0(react@19.2.6)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
       nanoid: 3.3.11
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       use-latest-callback: 0.2.6(react@19.2.6)
 
   '@react-navigation/routers@7.5.3':
@@ -18091,11 +18094,11 @@ snapshots:
       '@sentry/core': 10.53.1
       react: 19.2.6
 
-  '@shopify/flash-list@2.0.2(@babel/runtime@7.29.2)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
+  '@shopify/flash-list@2.0.2(@babel/runtime@7.29.2)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       tslib: 2.8.1
 
   '@simple-libs/child-process-utils@1.0.2':
@@ -18118,9 +18121,9 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@solana-mobile/mobile-wallet-adapter-protocol-web3js@2.2.9(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@solana-mobile/mobile-wallet-adapter-protocol-web3js@2.2.9(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.9(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.9(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
@@ -18129,41 +18132,41 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@solana-mobile/mobile-wallet-adapter-protocol@2.2.9(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@solana-mobile/mobile-wallet-adapter-protocol@2.2.9(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/kit': 6.9.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/wallet-standard-features': 1.3.0
       '@solana/wallet-standard-util': 1.1.2
       '@wallet-standard/core': 1.1.1
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - typescript
       - utf-8-validate
 
-  '@solana-mobile/wallet-adapter-mobile@2.2.9(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@solana-mobile/wallet-adapter-mobile@2.2.9(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.9(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)
-      '@solana-mobile/mobile-wallet-adapter-protocol-web3js': 2.2.9(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)
-      '@solana-mobile/wallet-standard-mobile': 0.5.3(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.9(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana-mobile/mobile-wallet-adapter-protocol-web3js': 2.2.9(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana-mobile/wallet-standard-mobile': 0.5.3(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/wallet-standard-features': 1.3.0
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@wallet-standard/core': 1.1.1
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       tslib: 2.8.1
     optionalDependencies:
-      '@react-native-async-storage/async-storage': 1.24.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+      '@react-native-async-storage/async-storage': 1.24.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
     transitivePeerDependencies:
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - typescript
       - utf-8-validate
 
-  '@solana-mobile/wallet-standard-mobile@0.5.3(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@solana-mobile/wallet-standard-mobile@0.5.3(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.9(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.9(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/wallet-standard-chains': 1.1.1
       '@solana/wallet-standard-features': 1.3.0
       '@wallet-standard/base': 1.1.1
@@ -18172,7 +18175,7 @@ snapshots:
       qrcode: 1.5.4
       tslib: 2.8.1
     optionalDependencies:
-      '@react-native-async-storage/async-storage': 1.24.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+      '@react-native-async-storage/async-storage': 1.24.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
     transitivePeerDependencies:
       - bufferutil
       - fastestsmallesttextencoderdecoder
@@ -18678,9 +18681,9 @@ snapshots:
       '@wallet-standard/features': 1.1.1
       eventemitter3: 5.0.4
 
-  '@solana/wallet-adapter-react@0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@solana/wallet-adapter-react@0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana-mobile/wallet-adapter-mobile': 2.2.9(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana-mobile/wallet-adapter-mobile': 2.2.9(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/wallet-standard-wallet-adapter-react': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(react@19.2.6)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -19128,13 +19131,13 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react-test-renderer@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react-test-renderer@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       jest-matcher-utils: 30.3.0
       picocolors: 1.1.1
       pretty-format: 30.3.0
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       react-test-renderer: 19.2.6(react@19.2.6)
       redent: 3.0.0
     optionalDependencies:
@@ -19496,9 +19499,9 @@ snapshots:
     dependencies:
       '@types/react': 19.2.14
 
-  '@types/react-native@0.73.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)':
+  '@types/react-native@0.73.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)':
     dependencies:
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@babel/core'
       - '@react-native-community/cli'
@@ -19510,9 +19513,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@types/react-native@0.73.0(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)':
+  '@types/react-native@0.73.0(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)':
     dependencies:
-      react-native: 0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@babel/core'
       - '@react-native-community/cli'
@@ -20578,7 +20581,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -21839,8 +21842,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.1
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -21873,7 +21876,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -21884,7 +21887,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -21903,6 +21906,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
@@ -21912,6 +21926,35 @@ snapshots:
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 10.2.4
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
 
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
@@ -22130,146 +22173,146 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
-  expo-apple-authentication@55.0.13(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
+  expo-apple-authentication@55.0.13(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
   expo-application@55.0.15(expo@55.0.24):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
-  expo-asset@55.0.17(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3):
+  expo-asset@55.0.17(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
-      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-background-fetch@55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
+  expo-background-fetch@55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
-      expo-task-manager: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      expo-task-manager: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
     transitivePeerDependencies:
       - react-native
 
-  expo-calendar@55.0.14(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
+  expo-calendar@55.0.14(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
-  expo-camera@55.0.18(@types/emscripten@1.41.5)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  expo-camera@55.0.18(@types/emscripten@1.41.5)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       barcode-detector: 3.1.1(@types/emscripten@1.41.5)
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@types/emscripten'
 
-  expo-clipboard@55.0.13(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  expo-clipboard@55.0.13(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
-  expo-constants@55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
+  expo-constants@55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
     dependencies:
       '@expo/env': 2.1.2
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
 
-  expo-contacts@55.0.14(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  expo-contacts@55.0.14(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
   expo-crypto@55.0.15(expo@55.0.24):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
   expo-document-picker@55.0.13(expo@55.0.24):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
   expo-eas-client@55.0.5: {}
 
-  expo-file-system@55.0.20(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
+  expo-file-system@55.0.20(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
-  expo-font@55.0.7(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  expo-font@55.0.7(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       fontfaceobserver: 2.3.0
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
-  expo-glass-effect@55.0.11(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  expo-glass-effect@55.0.11(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
   expo-haptics@55.0.14(expo@55.0.24):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
   expo-image-loader@55.0.0(expo@55.0.24):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
   expo-image-picker@55.0.20(expo@55.0.24):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       expo-image-loader: 55.0.0(expo@55.0.24)
 
-  expo-image@55.0.10(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  expo-image@55.0.10(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       sf-symbols-typescript: 2.2.0
 
   expo-json-utils@55.0.2: {}
 
   expo-keep-awake@55.0.8(expo@55.0.24)(react@19.2.6):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.6
 
-  expo-linking@55.0.15(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  expo-linking@55.0.15(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
-      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       invariant: 2.2.4
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - expo
       - supports-color
 
   expo-local-authentication@55.0.14(expo@55.0.24):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       invariant: 2.2.4
 
   expo-localization@55.0.15(expo@55.0.24)(react@19.2.6):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.6
       rtl-detect: 1.1.2
 
   expo-manifests@55.0.17(expo@55.0.24):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       expo-json-utils: 55.0.2
 
   expo-modules-autolinking@55.0.22(typescript@5.9.3):
@@ -22282,63 +22325,63 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-modules-core@55.0.25(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  expo-modules-core@55.0.25(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       invariant: 2.2.4
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     optionalDependencies:
-      react-native-worklets: 0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-worklets: 0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
 
-  expo-notifications@55.0.23(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3):
+  expo-notifications@55.0.23(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
       abort-controller: 3.0.0
       badgin: 1.2.3
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       expo-application: 55.0.15(expo@55.0.24)
-      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-print@55.0.15(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
+  expo-print@55.0.15(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
-  expo-router@55.0.14(n4bhh46ocnqckxeacbx7tz5z2q):
+  expo-router@55.0.14(g6uw2d3pskkivjko2jfnh74tr4):
     dependencies:
-      '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       '@expo/schema-utils': 55.0.4
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-navigation/bottom-tabs': 7.15.7(j4qkvs7upklbniepmc76d4ynk4)
-      '@react-navigation/native': 7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      '@react-navigation/native-stack': 7.14.7(j4qkvs7upklbniepmc76d4ynk4)
+      '@react-navigation/bottom-tabs': 7.15.7(@react-navigation/native@7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-safe-area-context@5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-screens@4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@react-navigation/native': 7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@react-navigation/native-stack': 7.14.7(@react-navigation/native@7.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-safe-area-context@5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-screens@4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       client-only: 0.0.1
       debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
-      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
-      expo-glass-effect: 55.0.11(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      expo-image: 55.0.10(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      expo-linking: 55.0.15(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+      expo-glass-effect: 55.0.11(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      expo-image: 55.0.10(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      expo-linking: 55.0.15(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo-server: 55.0.9
-      expo-symbols: 55.0.8(expo-font@55.0.7)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      expo-symbols: 55.0.8(expo-font@55.0.7)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
       nanoid: 3.3.11
       query-string: 7.1.3
       react: 19.2.6
       react-fast-compare: 3.2.2
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-safe-area-context: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-screens: 4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-screens: 4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       semver: 7.6.3
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
@@ -22346,11 +22389,11 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.2.6)
       vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     optionalDependencies:
-      '@react-navigation/drawer': 7.9.6(qwrsk7whjxbzfhkagqa7vqfdpu)
-      '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react-test-renderer@19.2.6(react@19.2.6))(react@19.2.6)
+      '@react-navigation/drawer': 7.9.6(5cjugtjgehekxhv4zj5ab4jqii)
+      '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react-test-renderer@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
-      react-native-gesture-handler: 2.30.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-gesture-handler: 2.30.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
       - '@types/react'
@@ -22360,74 +22403,74 @@ snapshots:
 
   expo-secure-store@55.0.14(expo@55.0.24):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
   expo-server@55.0.9: {}
 
-  expo-sharing@55.0.19(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  expo-sharing@55.0.19(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       '@expo/config-plugins': 55.0.9
       '@expo/config-types': 55.0.5
       '@expo/plist': 0.5.3
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
 
-  expo-speech-recognition@3.1.3(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  expo-speech-recognition@3.1.3(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
   expo-speech@55.0.14(expo@55.0.24):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
   expo-splash-screen@55.0.21(expo@55.0.24)(typescript@5.9.3):
     dependencies:
       '@expo/prebuild-config': 55.0.18(expo@55.0.24)(typescript@5.9.3)
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-sqlite@55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  expo-sqlite@55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       await-lock: 2.2.2
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
-  expo-status-bar@55.0.6(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  expo-status-bar@55.0.6(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
 
   expo-structured-headers@55.0.2: {}
 
-  expo-symbols@55.0.8(expo-font@55.0.7)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  expo-symbols@55.0.8(expo-font@55.0.7)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.27
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
-      expo-font: 55.0.7(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      expo-font: 55.0.7(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       sf-symbols-typescript: 2.2.0
 
-  expo-task-manager@55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
+  expo-task-manager@55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       unimodules-app-loader: 55.0.5
 
   expo-updates-interface@55.1.6(expo@55.0.24):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
-  expo-updates@55.0.22(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  expo-updates@55.0.22(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/plist': 0.5.3
@@ -22435,7 +22478,7 @@ snapshots:
       arg: 4.1.3
       chalk: 4.1.2
       debug: 4.4.3(supports-color@8.1.1)
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       expo-eas-client: 55.0.5
       expo-manifests: 55.0.17(expo@55.0.24)
       expo-structured-headers: 55.0.2
@@ -22444,47 +22487,47 @@ snapshots:
       glob: 13.0.6
       ignore: 5.3.2
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       resolve-from: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  expo-web-browser@55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
+  expo-web-browser@55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
-  expo@55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq):
+  expo@55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@expo/cli': 55.0.30(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-constants@55.0.16)(expo-font@55.0.7)(expo-router@55.0.14)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@expo/cli': 55.0.30(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-constants@55.0.16)(expo-font@55.0.7)(expo-router@55.0.14)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@expo/config': 55.0.17(typescript@5.9.3)
       '@expo/config-plugins': 55.0.9
-      '@expo/devtools': 55.0.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@expo/devtools': 55.0.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       '@expo/fingerprint': 0.16.7
       '@expo/local-build-cache-provider': 55.0.13(typescript@5.9.3)
-      '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       '@expo/metro': 55.1.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@expo/metro-config': 55.0.21(bufferutil@4.1.0)(expo@55.0.24)(typescript@5.9.3)(utf-8-validate@6.0.6)
-      '@expo/vector-icons': 15.1.1(expo-font@55.0.7)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@expo/vector-icons': 15.1.1(expo-font@55.0.7)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       '@ungap/structured-clone': 1.3.0
       babel-preset-expo: 55.0.21(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@55.0.24)(react-refresh@0.14.2)
-      expo-asset: 55.0.17(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)
-      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
-      expo-file-system: 55.0.20(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
-      expo-font: 55.0.7(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      expo-asset: 55.0.17(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)
+      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+      expo-file-system: 55.0.20(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+      expo-font: 55.0.7(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo-keep-awake: 55.0.8(expo@55.0.24)(react@19.2.6)
       expo-modules-autolinking: 55.0.22(typescript@5.9.3)
-      expo-modules-core: 55.0.25(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      expo-modules-core: 55.0.25(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       pretty-format: 29.7.0
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       react-refresh: 0.14.2
       whatwg-url-minimum: 0.1.2
     optionalDependencies:
-      '@expo/dom-webview': 55.0.6(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-webview: 13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@expo/dom-webview': 55.0.6(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-webview: 13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -23701,21 +23744,21 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@55.0.17(@babel/core@7.29.0)(bufferutil@4.1.0)(expo@55.0.24)(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6):
+  jest-expo@55.0.17(@babel/core@7.29.0)(bufferutil@4.1.0)(expo@55.0.24)(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6):
     dependencies:
       '@expo/config': 55.0.16(typescript@5.9.3)
       '@expo/json-file': 10.0.14
       '@jest/create-cache-key-function': 29.7.0
       '@jest/globals': 29.7.0
       babel-jest: 29.7.0(@babel/core@7.29.0)
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       jest-environment-jsdom: 29.7.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
       jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))
       json5: 2.2.3
       lodash: 4.18.1
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       react-test-renderer: 19.2.6(react@19.2.6)
       server-only: 0.0.1
       stacktrace-js: 2.0.2
@@ -24278,10 +24321,10 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
-  llama.rn@0.10.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  llama.rn@0.10.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
   locate-path@5.0.0:
     dependencies:
@@ -24390,11 +24433,11 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
-  lucide-react-native@0.577.0(react-native-svg@15.15.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  lucide-react-native@0.577.0(react-native-svg@15.15.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
-      react-native-svg: 15.15.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native-svg: 15.15.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
 
   lucide-react@1.16.0(react@19.2.6):
     dependencies:
@@ -25397,11 +25440,11 @@ snapshots:
 
   napi-postinstall@0.3.4: {}
 
-  nativewind@4.2.3(4n25dg5g6d76yfbhsmprwdwrty):
+  nativewind@4.2.3(dqaevcjldhvzporyuwciexzmmm):
     dependencies:
       comment-json: 4.6.2
       debug: 4.4.3(supports-color@8.1.1)
-      react-native-css-interop: 0.2.3(4n25dg5g6d76yfbhsmprwdwrty)
+      react-native-css-interop: 0.2.3(dqaevcjldhvzporyuwciexzmmm)
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - react
@@ -26190,7 +26233,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-native-css-interop@0.2.3(4n25dg5g6d76yfbhsmprwdwrty):
+  react-native-css-interop@0.2.3(dqaevcjldhvzporyuwciexzmmm):
     dependencies:
       '@babel/helper-module-imports': 7.28.6
       '@babel/traverse': 7.29.0
@@ -26198,111 +26241,111 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       lightningcss: 1.27.0
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       semver: 7.8.1
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
     optionalDependencies:
-      react-native-safe-area-context: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-svg: 15.15.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-svg: 15.15.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
 
-  react-native-drawer-layout@4.2.2(3qthecrptfltn7nk7tqaurr7uq):
+  react-native-drawer-layout@4.2.2(react-native-gesture-handler@2.30.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-reanimated@4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       color: 4.2.3
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
-      react-native-gesture-handler: 2.30.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native-gesture-handler: 2.30.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       use-latest-callback: 0.2.6(react@19.2.6)
 
-  react-native-executorch-expo-resource-fetcher@0.8.0(pfkl2nycxdmijgx66zi7jxoftu):
+  react-native-executorch-expo-resource-fetcher@0.8.0(expo-asset@55.0.17(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3))(expo-file-system@55.0.20(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)))(expo@55.0.24)(react-native-executorch@0.8.4(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(bdhntul2f4msu5vrifvtqbi7sq)
-      expo-asset: 55.0.17(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)
-      expo-file-system: 55.0.20(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
-      react-native-executorch: 0.8.4(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      expo: 55.0.24(patch_hash=afdzxrbf6nztsgxkuepwxbjrlq)(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      expo-asset: 55.0.17(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)
+      expo-file-system: 55.0.20(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native-executorch: 0.8.4(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
 
-  react-native-executorch@0.8.4(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  react-native-executorch@0.8.4(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       '@huggingface/jinja': 0.5.9
       jsonrepair: 3.14.0
       jsonschema: 1.5.0
       pngjs: 7.0.0
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       zod: 4.4.3
 
-  react-native-gesture-handler@2.30.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  react-native-gesture-handler@2.30.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
-  react-native-is-edge-to-edge@1.3.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  react-native-is-edge-to-edge@1.3.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
-  react-native-mmkv@3.3.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  react-native-mmkv@3.3.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
-  react-native-reanimated@4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  react-native-reanimated@4.3.1(react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-worklets: 0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-worklets: 0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       semver: 7.7.4
 
-  react-native-safe-area-context@5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  react-native-safe-area-context@5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
-  react-native-screens@4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  react-native-screens@4.23.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
       react-freeze: 1.0.4(react@19.2.6)
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       warn-once: 0.1.1
 
-  react-native-svg@15.15.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  react-native-svg@15.15.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       css-select: 5.2.2
       css-tree: 1.1.3
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       warn-once: 0.1.1
 
-  react-native-url-polyfill@2.0.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
+  react-native-url-polyfill@2.0.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
     dependencies:
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       whatwg-url-without-unicode: 8.0.0-3
 
-  react-native-webrtc@124.0.7(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
+  react-native-webrtc@124.0.7(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
     dependencies:
       base64-js: 1.5.1
       debug: 4.3.4
       event-target-shim: 6.0.2
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
 
-  react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  react-native-webview@13.16.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       escape-string-regexp: 4.0.0
       invariant: 2.2.4
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
-  react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  react-native-worklets@0.8.0(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -26314,24 +26357,24 @@ snapshots:
       '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@react-native/metro-config': 0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@react-native/metro-config': 0.85.3(@babel/core@7.29.0)
       convert-source-map: 2.0.0
       react: 19.2.6
-      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
-  react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6):
+  react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.83.6
       '@react-native/codegen': 0.83.6(@babel/core@7.29.0)
-      '@react-native/community-cli-plugin': 0.83.6(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@react-native/community-cli-plugin': 0.83.6(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@react-native/gradle-plugin': 0.83.6
       '@react-native/js-polyfills': 0.83.6
       '@react-native/normalize-colors': 0.83.6
-      '@react-native/virtualized-lists': 0.83.6(@types/react@19.2.14)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@react-native/virtualized-lists': 0.83.6(@types/react@19.2.14)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -26370,16 +26413,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6):
+  react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.83.6
       '@react-native/codegen': 0.83.6(@babel/core@7.29.7)
-      '@react-native/community-cli-plugin': 0.83.6(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@react-native/community-cli-plugin': 0.83.6(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@react-native/gradle-plugin': 0.83.6
       '@react-native/js-polyfills': 0.83.6
       '@react-native/normalize-colors': 0.83.6
-      '@react-native/virtualized-lists': 0.83.6(@types/react@19.2.14)(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      '@react-native/virtualized-lists': 0.83.6(@types/react@19.2.14)(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -26818,7 +26861,7 @@ snapshots:
 
   rpc-websockets@9.3.9:
     dependencies:
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.21
       '@types/uuid': 10.0.0
       '@types/ws': 8.18.1
       buffer: 6.0.3


### PR DESCRIPTION
Demo-readiness branch for the founder demo. Bundles Local/Cloud separation + the #389 web/extension foundation + the demo-critical free-tier + hero work. Desktop sidebar WIP regression reverted.

## ✅ LIVE-VERIFIED (observed in browser on localhost:3000, not just code)
- **Web free-tier model gating** — free account sees economy models selectable (incl. **GPT-5.4 Mini**); premium (Claude Sonnet/Opus, GPT-5.5, Gemini Pro…) show **UPGRADE/PRO** badges and are locked; clicking a premium model opens the **"Upgrade hosted cloud" waitlist dialog** and does NOT select it. No console errors. Matches the founder spec exactly.
- **Web renders clean** — caught + fixed a real demo-breaker: shared `@agiworkforce/ui` sidebar components lacked `'use client'`, 500ing every page that imports the package (tsc didn't catch it). `/`, `/pricing` → 200, `/chat` → 307.

## ✅ Code-complete + verified at build/test level
- **Web free chat for a brand-new public user** — now works **without infra flags**: free-trial requests bypass the managed-compute gate; missing `CSRF_SECRET` fails safe (no 500); new users auto-provisioned (no 402).
- **Local/Cloud strict separation** (desktop + mobile) — silent Local→Cloud redirect killed, mode coercion removed, toggle authoritative, mobile stores physically split. Desktop 4212 Rust tests pass; mobile typecheck + tests pass.
- **Extension computer-use HERO** — 3 gateway blockers fixed (wrong path `/v1`→`/api/llm/v1`, missing `X-Requested-With` + `x-agi-managed-compute-beta` headers); host_permissions; free-tier gating. 904 tests pass.

## 🔑 Founder pre-demo checklist (infra/account — only you)
1. **Web deploy env:** `CLERK_SECRET_KEY`, `CSRF_SECRET` (≥32 bytes), Neon URL, and the **Google provider key** (free chat = `gemini-3.1-flash-lite`). Pre-test the 3-prompt flow on prod.
2. **Hero env:** set `AGI_MANAGED_COMPUTE_PRIVATE_BETA=1` on the `api.agiworkforce.com` gateway + redeploy.
3. **Hero account must be Pro** — gpt-5.4-mini computer-use is 403'd for free/hobby. Confirm `subscriptions.plan_tier='pro'` in Neon.
4. **Pre-paste a Clerk token** into the extension drawer (sign-in handoff is still manual).

## Narration note
Free **chat** defaults to **gemini-3.1-flash-lite**; **gpt-5.4-mini** is selectable for free chat AND is the computer-use HERO model (needs Pro). Don't say "free chat uses gpt-5.4-mini."

## Frozen (not in this PR)
Cross-surface cloud sync, desktop/web UI parity, the 5,684-finding audit backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud chat mode with free 3-prompt trial for signed-in users
  * Local-to-cloud conversation sync with explicit user confirmation
  * App mode switching (local/cloud) with consent confirmation
  * Enhanced model selection UI with tier-based gating (Pro models require upgrade)

* **Bug Fixes**
  * Improved gateway endpoint routing for API calls
  * Enhanced error handling for auth and quota failures
  * Fixed CSRF security handling to prevent crashes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->