### PR TITLE
test(mobile): realign cloud-mode test with cloud-chat-enabled behavior

### DIFF
--- a/apps/mobile/__tests__/local-byok-handoff.test.ts
+++ b/apps/mobile/__tests__/local-byok-handoff.test.ts
@@ -169,11 +169,13 @@ describe('mobile local conversation forks', () => {
     useProjectStore.getState().setActiveProject('local-project');
     useChatAppModeStore.setState({ appMode: 'cloud' });
 
+    // Cloud chat is enabled now, so Cloud mode attempts a real cloud conversation;
+    // with no reachable cloud in the test env it fails — but it must NOT silently
+    // fall back to a local conversation (the strict Local/Cloud separation invariant).
     await expect(useChatStore.getState().createConversation('Cloud attempt')).rejects.toThrow(
-      'AGI Cloud chat is not enabled in this mobile build.',
+      'AGI Cloud conversation could not be created.',
     );
 
-    expect(api.post).not.toHaveBeenCalled();
     expect(
       useChatStore
         .getState()


### PR DESCRIPTION
Hotfix: #390 merged before this test fix landed, so main has the stale local-byok-handoff.test.ts. Phase-1 separation enabled cloud chat (v1LocalOnly=false), so the cloud-mode test now fails with 'AGI Cloud conversation could not be created.' instead of the old 'not enabled' message. Verified locally: 5/5 pass. The separation invariant (no local fallback in cloud mode) still holds and is still asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)