### PR TITLE
feat(chat): inline tool-call UI parity with reference (shared, desktop/web/mobile)

### DIFF
--- a/apps/desktop/src/features/chat/MessageBubble/MessageBubble.tsx
+++ b/apps/desktop/src/features/chat/MessageBubble/MessageBubble.tsx
@@ -569,11 +569,9 @@ const MessageBubbleComponent: React.FC<MessageBubbleProps> = ({
                 key={entry.id}
                 variant="tool"
                 iconName={getToolIconName(entry.displayName)}
-                label={
-                  entry.displayArgs
-                    ? `${entry.displayName} — ${entry.displayArgs}`
-                    : entry.displayName
-                }
+                label={entry.displayName}
+                chip={entry.displayArgs || undefined}
+                request={entry.displayArgs || undefined}
                 result={entry.resultPreview}
                 isError={entry.status === 'error'}
                 isRunning={entry.status === 'running'}

--- a/apps/desktop/src/features/chat/MessageBubble/MessageBubble.tsx
+++ b/apps/desktop/src/features/chat/MessageBubble/MessageBubble.tsx
@@ -7,7 +7,7 @@
 
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Check, ChevronDown, ChevronRight, Copy } from 'lucide-react';
-import { getToolIconName } from '@agiworkforce/types';
+import { getToolIconName, getToolSourceBadge } from '@agiworkforce/types';
 import { toast } from 'sonner';
 
 // Stable empty array reference to avoid infinite re-render in Zustand selectors.
@@ -568,7 +568,8 @@ const MessageBubbleComponent: React.FC<MessageBubbleProps> = ({
               <TimelineStep
                 key={entry.id}
                 variant="tool"
-                iconName={getToolIconName(entry.displayName)}
+                iconName={getToolIconName(entry.rawName ?? entry.displayName)}
+                sourceBadge={getToolSourceBadge(entry.rawName)}
                 label={entry.displayName}
                 chip={entry.displayArgs || undefined}
                 request={entry.displayArgs || undefined}

--- a/apps/desktop/src/features/chat/MessageBubble/MessageBubble.tsx
+++ b/apps/desktop/src/features/chat/MessageBubble/MessageBubble.tsx
@@ -554,7 +554,7 @@ const MessageBubbleComponent: React.FC<MessageBubbleProps> = ({
             <TimelineStep
               key="thinking"
               variant="thinking"
-              label={messageThinkingContent.slice(0, 200)}
+              label={messageThinkingContent}
               isRunning={isStreaming && messageToolTimeline.length === 0}
               isLast={++stepIndex >= totalSteps}
             />

--- a/apps/desktop/src/features/chat/MessageBubble/MessageBubble.tsx
+++ b/apps/desktop/src/features/chat/MessageBubble/MessageBubble.tsx
@@ -7,6 +7,7 @@
 
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Check, ChevronDown, ChevronRight, Copy } from 'lucide-react';
+import { getToolIconName } from '@agiworkforce/types';
 import { toast } from 'sonner';
 
 // Stable empty array reference to avoid infinite re-render in Zustand selectors.
@@ -567,6 +568,7 @@ const MessageBubbleComponent: React.FC<MessageBubbleProps> = ({
               <TimelineStep
                 key={entry.id}
                 variant="tool"
+                iconName={getToolIconName(entry.displayName)}
                 label={
                   entry.displayArgs
                     ? `${entry.displayName} — ${entry.displayArgs}`

--- a/apps/desktop/src/features/chat/Timeline/TimelineStep.tsx
+++ b/apps/desktop/src/features/chat/Timeline/TimelineStep.tsx
@@ -16,6 +16,12 @@ export interface TimelineStepProps {
    */
   iconName?: string;
   /**
+   * One-letter integration source badge (Claude-style "F" mark) for MCP/connector
+   * tools, from `getToolSourceBadge`. Rendered before the label; omit for native
+   * tools.
+   */
+  sourceBadge?: string | null;
+  /**
    * Short type/arg chip rendered on its own line under the label (Claude inline
    * tool-call style — e.g. a filename `build_resume.js`, a query, or `Script`).
    */
@@ -33,6 +39,7 @@ export function TimelineStep({
   variant,
   label,
   iconName,
+  sourceBadge,
   chip,
   request,
   result,
@@ -95,6 +102,14 @@ export function TimelineStep({
       {/* Content column */}
       <div className="flex-1 min-w-0 pb-3">
         <div className="flex items-center gap-2 flex-wrap">
+          {variant === 'tool' && sourceBadge && (
+            <span
+              title="Integration"
+              className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded bg-muted text-[9px] font-bold text-muted-foreground"
+            >
+              {sourceBadge}
+            </span>
+          )}
           <span
             className={cn(
               'text-xs',

--- a/apps/desktop/src/features/chat/Timeline/TimelineStep.tsx
+++ b/apps/desktop/src/features/chat/Timeline/TimelineStep.tsx
@@ -15,6 +15,13 @@ export interface TimelineStepProps {
    * registry drives desktop/web and mobile. Ignored for thinking/done variants.
    */
   iconName?: string;
+  /**
+   * Short type/arg chip rendered on its own line under the label (Claude inline
+   * tool-call style — e.g. a filename `build_resume.js`, a query, or `Script`).
+   */
+  chip?: string;
+  /** Tool request/args, shown as a labelled "Request" block in the expand. */
+  request?: string;
   result?: string;
   isError?: boolean;
   isRunning?: boolean;
@@ -26,6 +33,8 @@ export function TimelineStep({
   variant,
   label,
   iconName,
+  chip,
+  request,
   result,
   isError = false,
   isRunning = false,
@@ -62,7 +71,9 @@ export function TimelineStep({
     return <CheckCircle2 className="w-3.5 h-3.5 shrink-0 text-emerald-500" />;
   })();
 
-  const hasResult = variant === 'tool' && result !== undefined && result !== null;
+  const hasResult =
+    variant === 'tool' &&
+    ((result !== undefined && result !== null) || (request !== undefined && request !== null));
 
   return (
     <div className="relative flex gap-3">
@@ -121,6 +132,15 @@ export function TimelineStep({
           )}
         </div>
 
+        {/* Type / arg chip on its own line (Claude inline tool-call style) */}
+        {variant === 'tool' && chip && (
+          <div className="mt-1">
+            <span className="inline-flex max-w-full items-center truncate rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground/90">
+              {chip}
+            </span>
+          </div>
+        )}
+
         {/* Result content */}
         <AnimatePresence initial={false}>
           {hasResult && resultOpen && (
@@ -131,14 +151,38 @@ export function TimelineStep({
               transition={{ duration: 0.2, ease: 'easeInOut' }}
               className="overflow-hidden"
             >
-              <pre
-                className={cn(
-                  'mt-1.5 max-h-64 overflow-y-auto rounded p-2 text-[11px] font-mono leading-relaxed whitespace-pre-wrap break-words',
-                  isError ? 'bg-red-950/40 text-red-300' : 'bg-card/60 text-foreground',
-                )}
-              >
-                {result}
-              </pre>
+              {/* Request block (tool args) — Claude inline expanded-detail style */}
+              {request != null && request !== '' && (
+                <>
+                  <div className="mt-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">
+                    Request
+                  </div>
+                  <pre className="mt-1 max-h-48 overflow-y-auto rounded bg-card/60 p-2 font-mono text-[11px] leading-relaxed break-words whitespace-pre-wrap text-foreground">
+                    {request}
+                  </pre>
+                </>
+              )}
+              {/* Response block (tool result) */}
+              {result != null && result !== '' && (
+                <>
+                  <div
+                    className={cn(
+                      'mt-1.5 text-[10px] font-medium uppercase tracking-wide',
+                      isError ? 'text-red-400/80' : 'text-muted-foreground/70',
+                    )}
+                  >
+                    {isError ? 'Error' : 'Response'}
+                  </div>
+                  <pre
+                    className={cn(
+                      'mt-1 max-h-64 overflow-y-auto rounded p-2 font-mono text-[11px] leading-relaxed break-words whitespace-pre-wrap',
+                      isError ? 'bg-red-950/40 text-red-300' : 'bg-card/60 text-foreground',
+                    )}
+                  >
+                    {result}
+                  </pre>
+                </>
+              )}
             </motion.div>
           )}
         </AnimatePresence>

--- a/apps/desktop/src/features/chat/Timeline/TimelineStep.tsx
+++ b/apps/desktop/src/features/chat/Timeline/TimelineStep.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { CheckCircle2, ChevronDown, Clock, Link2 } from 'lucide-react';
+import { CheckCircle2, ChevronDown, Clock } from 'lucide-react';
+import { lucideToolIcon } from '@agiworkforce/ui';
 import { cn } from '../../../lib/utils';
 
 export type StepVariant = 'thinking' | 'tool' | 'done';
@@ -8,6 +9,12 @@ export type StepVariant = 'thinking' | 'tool' | 'done';
 export interface TimelineStepProps {
   variant: StepVariant;
   label: string;
+  /**
+   * Lucide icon NAME for the tool step (from `getToolIconName` in
+   * @agiworkforce/types). Resolved to a lucide-react component here so the same
+   * registry drives desktop/web and mobile. Ignored for thinking/done variants.
+   */
+  iconName?: string;
   result?: string;
   isError?: boolean;
   isRunning?: boolean;
@@ -18,6 +25,7 @@ export interface TimelineStepProps {
 export function TimelineStep({
   variant,
   label,
+  iconName,
   result,
   isError = false,
   isRunning = false,
@@ -38,7 +46,17 @@ export function TimelineStep({
       );
     }
     if (variant === 'tool') {
-      return <Link2 className="w-3.5 h-3.5 shrink-0 text-muted-foreground" />;
+      // Per-tool icon resolved from the shared cross-surface registry, replacing
+      // the previous single generic icon used for every tool.
+      const ToolIcon = lucideToolIcon(iconName ?? 'Wrench');
+      return (
+        <ToolIcon
+          className={cn(
+            'w-3.5 h-3.5 shrink-0',
+            isRunning ? 'animate-pulse text-amber-400' : 'text-muted-foreground',
+          )}
+        />
+      );
     }
     // done
     return <CheckCircle2 className="w-3.5 h-3.5 shrink-0 text-emerald-500" />;

--- a/apps/desktop/src/features/chat/Timeline/TimelineStep.tsx
+++ b/apps/desktop/src/features/chat/Timeline/TimelineStep.tsx
@@ -42,6 +42,13 @@ export function TimelineStep({
   duration,
 }: TimelineStepProps) {
   const [resultOpen, setResultOpen] = useState(false);
+  const [textExpanded, setTextExpanded] = useState(false);
+
+  // "Show more" for long thinking blocks (Claude inline reasoning style, ref 386).
+  const THINKING_TRUNCATE = 240;
+  const isLongThinking = variant === 'thinking' && label.length > THINKING_TRUNCATE;
+  const shownLabel =
+    isLongThinking && !textExpanded ? `${label.slice(0, THINKING_TRUNCATE).trimEnd()}…` : label;
 
   const icon = (() => {
     if (variant === 'thinking') {
@@ -98,7 +105,16 @@ export function TimelineStep({
                   : 'text-foreground/80',
             )}
           >
-            {label}
+            {shownLabel}
+            {isLongThinking && (
+              <button
+                type="button"
+                onClick={() => setTextExpanded((o) => !o)}
+                className="ml-1 not-italic font-medium text-muted-foreground/80 hover:text-foreground"
+              >
+                {textExpanded ? 'Show less' : 'Show more'}
+              </button>
+            )}
           </span>
 
           {/* Duration badge */}

--- a/apps/desktop/src/lib/toolTimelineRuntime.ts
+++ b/apps/desktop/src/lib/toolTimelineRuntime.ts
@@ -144,6 +144,7 @@ export function buildRunningToolTimelineEntry(input: {
     displayName: label.displayName,
     displayArgs: label.displayArgs,
     status: 'running',
+    ...(input.rawName ? { rawName: input.rawName } : {}),
     ...(input.parallelGroup ? { parallelGroup: input.parallelGroup } : {}),
   };
 }

--- a/apps/mobile/src/features/chat/components/InlineToolCall.tsx
+++ b/apps/mobile/src/features/chat/components/InlineToolCall.tsx
@@ -2,48 +2,11 @@ import { useCallback, useRef } from 'react';
 import { View, Pressable, ScrollView } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import BottomSheet, { BottomSheetScrollView, BottomSheetBackdrop } from '@gorhom/bottom-sheet';
-import {
-  Terminal,
-  FileText,
-  FilePlus2,
-  FilePen,
-  Search,
-  Globe,
-  Folder,
-  Image,
-  MousePointerClick,
-  Plug,
-  CircleCheck,
-  Loader2,
-  CircleX,
-  ChevronRight,
-  Wrench,
-} from 'lucide-react-native';
+import { CircleCheck, Loader2, CircleX, ChevronRight } from 'lucide-react-native';
+import { lucideRNToolIcon } from './toolIconRN';
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/src/ui/theme';
 import type { ToolCall } from '@/types/chat';
-
-// §4.6 icon mapping
-function getToolIcon(toolName: string): typeof Terminal {
-  const name = toolName.toLowerCase();
-  if (name.includes('bash') || name.includes('shell') || name.includes('terminal')) return Terminal;
-  if (name.includes('read')) return FileText;
-  if (name.includes('write') || name.includes('create')) return FilePlus2;
-  if (name.includes('edit') || name.includes('patch')) return FilePen;
-  if (name.includes('web_search') || name.includes('search')) return Search;
-  if (
-    name.includes('fetch') ||
-    name.includes('browse') ||
-    name.includes('url') ||
-    name.includes('http')
-  )
-    return Globe;
-  if (name.includes('list') || name.includes('dir') || name.includes('folder')) return Folder;
-  if (name.includes('image') || name.includes('gen')) return Image;
-  if (name.includes('browser') || name.includes('click')) return MousePointerClick;
-  if (name.includes('mcp') || name.includes('plugin')) return Plug;
-  return Wrench;
-}
 
 // §4.4 state label
 function getStatusLabel(status: ToolCall['status']): string | null {
@@ -84,7 +47,7 @@ export function InlineToolCall({ toolCall }: InlineToolCallProps) {
     chevronRotation.value = withTiming(0, { duration: 160 });
   }, [chevronRotation]);
 
-  const ToolIcon = getToolIcon(toolCall.name);
+  const ToolIcon = lucideRNToolIcon(toolCall.name);
   const statusLabel = getStatusLabel(toolCall.status);
 
   const iconColor =

--- a/apps/mobile/src/features/chat/components/ToolCallCard.tsx
+++ b/apps/mobile/src/features/chat/components/ToolCallCard.tsx
@@ -16,13 +16,8 @@ import {
   ChevronRight,
   FileCode,
   Clock,
-  Terminal,
-  FileText,
-  Edit3,
-  Globe,
-  Code,
-  Wrench,
 } from 'lucide-react-native';
+import { lucideRNToolIcon } from './toolIconRN';
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/src/ui/theme';
 import type { ToolCall } from '@/types/chat';
@@ -33,32 +28,6 @@ interface ToolCallCardProps {
   showRailAbove?: boolean;
   /** When true, draw the connecting rail line below this card. */
   showRailBelow?: boolean;
-}
-
-/** Map tool name patterns to a representative lucide icon. */
-function getToolIcon(toolName: string): typeof Terminal {
-  const name = toolName.toLowerCase();
-  if (name.includes('bash') || name.includes('shell') || name.includes('terminal')) {
-    return Terminal;
-  }
-  if (name.includes('read_file') || name.includes('read') || name.includes('file_text')) {
-    return FileText;
-  }
-  if (name.includes('write_file') || name.includes('edit') || name.includes('create_file')) {
-    return Edit3;
-  }
-  if (
-    name.includes('web_search') ||
-    name.includes('browse') ||
-    name.includes('url') ||
-    name.includes('http')
-  ) {
-    return Globe;
-  }
-  if (name.includes('code') || name.includes('exec') || name.includes('python')) {
-    return Code;
-  }
-  return Wrench;
 }
 
 /** Pulsing dot for the running state — mirrors StatusStep.tsx PulsingIndicator. */
@@ -200,7 +169,7 @@ export function ToolCallCard({
   const [expanded, setExpanded] = useState(false);
 
   const hasIO = Boolean(toolCall.input || toolCall.output);
-  const ToolIcon = getToolIcon(toolCall.name);
+  const ToolIcon = lucideRNToolIcon(toolCall.name);
 
   const toggleExpanded = useCallback(() => {
     if (hasIO) setExpanded((prev) => !prev);

--- a/apps/mobile/src/features/chat/components/toolIconRN.ts
+++ b/apps/mobile/src/features/chat/components/toolIconRN.ts
@@ -1,0 +1,64 @@
+/**
+ * React Native (lucide-react-native) resolver for the cross-surface tool-call
+ * icon registry.
+ *
+ * The icon NAME is decided by the platform-agnostic registry in
+ * `@agiworkforce/types` (getToolIconName) — the SAME registry desktop/web use
+ * via lucide-react. This maps that name to a lucide-react-native component so
+ * mobile renders the identical icon for the same tool. Replaces the per-file
+ * ad-hoc substring `getToolIcon` mappings that previously drifted apart.
+ */
+import {
+  Box,
+  CheckCircle2,
+  Clock,
+  Code,
+  Database,
+  Edit3,
+  FileText,
+  FolderOpen,
+  GitBranch,
+  Globe,
+  HelpCircle,
+  Image,
+  ListTodo,
+  MessageSquare,
+  MousePointerClick,
+  Search,
+  Settings,
+  Terminal,
+  Video,
+  Wrench,
+} from 'lucide-react-native';
+import { getToolIconName, type ToolDisplayCategory } from '@agiworkforce/types';
+
+const BY_NAME: Record<string, typeof Terminal> = {
+  Box,
+  CheckCircle2,
+  Clock,
+  Code,
+  Database,
+  Edit3,
+  FileText,
+  FolderOpen,
+  GitBranch,
+  Globe,
+  HelpCircle,
+  Image,
+  ListTodo,
+  MessageSquare,
+  MousePointerClick,
+  Search,
+  Settings,
+  Terminal,
+  Video,
+  Wrench,
+};
+
+/** Resolve a tool name (or friendly label) to a lucide-react-native icon. */
+export function lucideRNToolIcon(
+  toolName: string | null | undefined,
+  category?: ToolDisplayCategory | null,
+): typeof Terminal {
+  return BY_NAME[getToolIconName(toolName, category)] ?? Wrench;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -137,3 +137,7 @@ export * from './on-device-models';
 
 // Cross-surface application-suite contracts
 export * from './suite-contracts';
+
+// Cross-surface tool-call display registry (icon names + categories; pure TS,
+// shared by desktop/web via lucide-react and mobile via lucide-react-native)
+export * from './tool-display';

--- a/packages/types/src/tool-display.ts
+++ b/packages/types/src/tool-display.ts
@@ -106,6 +106,33 @@ export const TOOL_TIMELINE_ICON_NAME = {
 } as const;
 
 /**
+ * Short integration "source" badge for a tool, à la Claude's inline tool-call
+ * UI where MCP/connector tools show a letter mark (e.g. "F" for Filesystem)
+ * to the left of the step.
+ *
+ * Returns a 1-char uppercase badge for MCP/namespaced tools
+ * (`mcp__filesystem__list` → "F", `github__create_issue` → "G"), or null for
+ * native tools (which are represented by their own icon, no source mark).
+ */
+export function getToolSourceBadge(rawName: string | null | undefined): string | null {
+  const n = (rawName ?? '').trim();
+  if (!n) return null;
+  const mcp = n.match(/^mcp__([a-z0-9_-]+)__/i);
+  if (mcp?.[1])
+    return (
+      mcp[1]
+        .replace(/^[_-]+/, '')
+        .charAt(0)
+        .toUpperCase() || null
+    );
+  const composite = n.match(/^([a-z0-9-]+)__/i);
+  if (composite?.[1] && composite[1].toLowerCase() !== 'mcp') {
+    return composite[1].charAt(0).toUpperCase();
+  }
+  return null;
+}
+
+/**
  * Resolve the lucide icon name for a tool.
  *
  * @param name      raw tool name OR its friendly display name

--- a/packages/types/src/tool-display.ts
+++ b/packages/types/src/tool-display.ts
@@ -1,0 +1,130 @@
+/**
+ * Cross-surface tool-call display registry.
+ *
+ * PURE TypeScript — NO React, NO icon library. This is the single source of
+ * truth for how a tool call is presented (icon + category) across every surface:
+ *   - desktop / web (apps/desktop, served as web /chat) → map iconName → lucide-react
+ *   - mobile (apps/mobile, React Native)                → map iconName → lucide-react-native
+ *
+ * Icon names are lucide names that exist in BOTH lucide-react and
+ * lucide-react-native (same generated icon set), so every surface renders the
+ * same icon for the same tool. Keep this file dependency-free so React Native
+ * can import it without pulling in any DOM/React code.
+ */
+
+/** Icon category buckets, mirrored from the per-tool display metadata. */
+export type ToolDisplayCategory =
+  | 'search'
+  | 'browser'
+  | 'code'
+  | 'file'
+  | 'terminal'
+  | 'media'
+  | 'data'
+  | 'communication'
+  | 'system';
+
+/** Fallback icon per category — a lucide name valid in react + react-native. */
+export const CATEGORY_ICON_NAME: Record<ToolDisplayCategory, string> = {
+  search: 'Search',
+  browser: 'Globe',
+  code: 'Code',
+  file: 'FileText',
+  terminal: 'Terminal',
+  media: 'Image',
+  data: 'Database',
+  communication: 'MessageSquare',
+  system: 'Settings',
+};
+
+/**
+ * Direct tool-name → lucide icon name. Keys cover both canonical tool names
+ * (Read, Bash, WebSearch…) and the user-facing display names produced by the
+ * display map (e.g. 'Open website', 'Run command'), so a lookup works whether
+ * the caller has the raw name or the friendly label.
+ */
+export const TOOL_ICON_NAME: Record<string, string> = {
+  // Filesystem
+  Read: 'FileText',
+  Write: 'FileText',
+  Edit: 'Edit3',
+  MultiEdit: 'Edit3',
+  ApplyPatch: 'Edit3',
+  LS: 'FolderOpen',
+  Glob: 'FolderOpen',
+  // Search
+  Search: 'Search',
+  Grep: 'Search',
+  CodeSearch: 'Code',
+  // Terminal
+  Bash: 'Terminal',
+  // Web
+  WebSearch: 'Globe',
+  WebFetch: 'Globe',
+  // Data
+  Memory: 'Database',
+  // Git
+  Git: 'GitBranch',
+  // Media
+  ImageGen: 'Image',
+  VideoGen: 'Video',
+  // Interactive
+  Question: 'HelpCircle',
+  TodoWrite: 'ListTodo',
+  // Browser / UI automation
+  Click: 'MousePointerClick',
+  Clicking: 'MousePointerClick',
+  Browsing: 'Globe',
+  Typing: 'Edit3',
+  'Open website': 'Globe',
+  'Take screenshot': 'Image',
+  'Scroll page': 'Globe',
+  'Type text': 'Edit3',
+  // MCP friendly display names
+  'Run database query': 'Database',
+  'List tables': 'Database',
+  'Read file': 'FileText',
+  'Save file': 'FileText',
+  'List files': 'FolderOpen',
+  'List allowed folders': 'FolderOpen',
+  'Run command': 'Terminal',
+  'Run code': 'Code',
+  'Search the web': 'Globe',
+  'Create image': 'Image',
+  'Create video': 'Video',
+  // MCP source indicator
+  MCP: 'Box',
+};
+
+/** Default when nothing matches — a generic tool icon present in both libs. */
+export const DEFAULT_TOOL_ICON_NAME = 'Wrench';
+
+/** Step-variant icon names shared by the timeline UIs (thinking / done). */
+export const TOOL_TIMELINE_ICON_NAME = {
+  thinking: 'Clock',
+  done: 'CheckCircle2',
+} as const;
+
+/**
+ * Resolve the lucide icon name for a tool.
+ *
+ * @param name      raw tool name OR its friendly display name
+ * @param category  optional category (from the tool display metadata) used as a
+ *                  fallback when the name isn't in TOOL_ICON_NAME
+ */
+export function getToolIconName(
+  name: string | null | undefined,
+  category?: ToolDisplayCategory | null,
+): string {
+  const key = (name ?? '').trim();
+  if (key && TOOL_ICON_NAME[key]) return TOOL_ICON_NAME[key];
+  // Try a case-insensitive canonical match (e.g. "read" → "Read").
+  if (key) {
+    const canonical = Object.keys(TOOL_ICON_NAME).find(
+      (k) => k.toLowerCase() === key.toLowerCase(),
+    );
+    if (canonical) return TOOL_ICON_NAME[canonical] as string;
+  }
+  if (category && CATEGORY_ICON_NAME[category]) return CATEGORY_ICON_NAME[category];
+  return DEFAULT_TOOL_ICON_NAME;
+}

--- a/packages/types/src/tool-events.ts
+++ b/packages/types/src/tool-events.ts
@@ -378,4 +378,12 @@ export interface ToolLabelEntry {
    * Absent for all other tool types.
    */
   checkpointId?: string;
+
+  /**
+   * Raw (un-prettified) tool name, e.g. `"mcp__filesystem__list_directory"`.
+   * Preserved alongside `displayName` so the inline timeline can derive the
+   * integration "source" badge (Claude-style "F"-mark) via
+   * `getToolSourceBadge`. Absent for native tools dispatched without a raw name.
+   */
+  rawName?: string;
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -10,6 +10,7 @@
 export { ProviderMark, hasProviderMark } from './ProviderMark';
 export { AgiMark } from './AgiMark';
 export { cn } from './cn';
+export { lucideToolIcon } from './toolIcon';
 export {
   Sidebar,
   type SidebarProps,

--- a/packages/ui/src/toolIcon.ts
+++ b/packages/ui/src/toolIcon.ts
@@ -1,0 +1,61 @@
+/**
+ * DOM (lucide-react) resolver for the cross-surface tool-call icon registry.
+ *
+ * The icon NAME is decided by the platform-agnostic registry in
+ * `@agiworkforce/types` (getToolIconName); this maps that name to a concrete
+ * lucide-react component for desktop + web. Mobile has its own resolver against
+ * lucide-react-native using the SAME names, so all surfaces show one icon set.
+ *
+ * Explicit map (not `import * as`) so only the icons we use are bundled.
+ */
+import {
+  Box,
+  CheckCircle2,
+  Clock,
+  Code,
+  Database,
+  Edit3,
+  FileText,
+  FolderOpen,
+  GitBranch,
+  Globe,
+  HelpCircle,
+  Image,
+  ListTodo,
+  MessageSquare,
+  MousePointerClick,
+  Search,
+  Settings,
+  Terminal,
+  Video,
+  Wrench,
+  type LucideIcon,
+} from 'lucide-react';
+
+const BY_NAME: Record<string, LucideIcon> = {
+  Box,
+  CheckCircle2,
+  Clock,
+  Code,
+  Database,
+  Edit3,
+  FileText,
+  FolderOpen,
+  GitBranch,
+  Globe,
+  HelpCircle,
+  Image,
+  ListTodo,
+  MessageSquare,
+  MousePointerClick,
+  Search,
+  Settings,
+  Terminal,
+  Video,
+  Wrench,
+};
+
+/** Map a lucide icon NAME (from `getToolIconName`) to a lucide-react component. */
+export function lucideToolIcon(iconName: string): LucideIcon {
+  return BY_NAME[iconName] ?? Wrench;
+}


### PR DESCRIPTION
Builds the inline tool-call UI toward the Claude reference (`~/Desktop/reference/claude_reference`), all in shared packages so desktop/web/mobile stay identical.

- **Shared icon registry** (`@agiworkforce/types/tool-display`): pure-TS tool→lucide icon-NAME + category + `getToolIconName`/`getToolSourceBadge`. Names valid in both lucide-react (desktop/web via `@agiworkforce/ui` `lucideToolIcon`) and lucide-react-native (mobile `lucideRNToolIcon`). Replaces desktop's single generic Link2 and two duplicated mobile substring mappings.
- **Tool-type chip** on its own line under each step (ref 382).
- **Request/Response** labelled expand (ref 379).
- **Show more** for long thinking (ref 386).
- **MCP source badge** ("F"-style mark) — preserves rawName on the timeline entry (ref 378/379).

Note: web-search result cards (ref 381) and the broader inline result renderers (directory/terminal/git/db/screenshot…) already existed and are wired; they just need structured tool output.

types/ui/desktop/mobile typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a unified tool display system with source badges for better tool identification across platforms.
  * Enhanced timeline visualization with detailed tool information and improved expand/collapse for thinking steps.

* **Refactor**
  * Consolidated icon handling across desktop and mobile apps using shared helpers for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->