### PR TITLE
fix(cli): confirm signalled process groups are reaped before acknowledging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -763,7 +763,15 @@ jobs:
         # than gating shipping-binary lint here.
         run: |
           cargo clippy --workspace --lib \
-            --features "agiworkforce-desktop/ocr,agiworkforce-desktop/local-llm,agiworkforce-desktop/webrtc-support,agiworkforce-desktop/sentry,agiworkforce-desktop/local-whisper,agiworkforce-desktop/devtools" \
+            # NB3: `sentry` is NOT in this list because agiworkforce-desktop has no
+            # such feature. Cargo rejects an unknown feature before it lints
+            # anything ("none of the selected packages contains this feature"),
+            # so while it was listed this lane failed on every commit and linted
+            # zero lines. It went unnoticed because the lane only runs after
+            # `check` passes, which had not happened since 2026-07-21.
+            # Every name below is verified against [features] in
+            # apps/desktop/src-tauri/Cargo.toml.
+            --features "agiworkforce-desktop/ocr,agiworkforce-desktop/local-llm,agiworkforce-desktop/webrtc-support,agiworkforce-desktop/local-whisper,agiworkforce-desktop/devtools" \
             -- -D warnings
 
   # macOS smoke check: compile + clippy on the primary target platform.

--- a/apps/cli/src/process_tree.rs
+++ b/apps/cli/src/process_tree.rs
@@ -134,9 +134,15 @@ pub(crate) async fn terminate_owners_and_wait(
         .copied()
         .collect::<std::collections::HashSet<_>>();
     let deadline = Instant::now() + timeout;
+    // Every group we have signalled. The registry draining only proves we
+    // stopped TRACKING a tree — see `await_process_groups_reaped`.
+    let mut signalled = std::collections::HashSet::<u32>::new();
 
     loop {
-        let (process_ids, mut count_receiver) = {
+        // The registry guard is `std::sync::MutexGuard`, which is not `Send`.
+        // It must be dropped before any `.await`, or this whole future stops
+        // being `Send` and cannot be spawned.
+        let drained_or_next = {
             let registry = active_process_trees()
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -152,12 +158,20 @@ pub(crate) async fn terminate_owners_and_wait(
                     .values()
                     .any(|entry| entry.owner.is_some_and(|owner| owner_set.contains(&owner)))
             {
-                return Ok(());
+                None
+            } else {
+                Some((process_ids, registry.active_count.subscribe()))
             }
-            (process_ids, registry.active_count.subscribe())
+        };
+
+        let Some((process_ids, mut count_receiver)) = drained_or_next else {
+            // Registry is clear. That is necessary but NOT sufficient, so
+            // confirm against the OS before acknowledging.
+            return await_process_groups_reaped(&signalled, deadline).await;
         };
 
         for process_id in process_ids {
+            signalled.insert(process_id);
             if tokio::time::timeout_at(deadline, signal_process_tree(Some(process_id)))
                 .await
                 .is_err()
@@ -171,6 +185,61 @@ pub(crate) async fn terminate_owners_and_wait(
             return Err(process_tree_shutdown_timeout());
         }
     }
+}
+
+/// Wait until every signalled process group is actually gone from the OS.
+///
+/// `terminate_owners_and_wait` used to return as soon as the in-process
+/// registry drained. A registry entry disappears when its supervisor task drops
+/// the tracked child — which is the DIRECT child exiting, not the group being
+/// reaped. `killpg(SIGKILL)` is delivered asynchronously, so between those two
+/// moments the grandchildren are doomed but still present.
+///
+/// On an idle machine that window is invisible. Under load it is not: CI ran
+/// this alongside 1,833 other tests and caught shutdown acknowledging while
+/// `[pid, pid, pid]` were still alive, which is precisely the contract
+/// `shutdown()` advertises and did not keep. It failed 100 consecutive runs and
+/// blocked every downstream E2E job for 18 days.
+///
+/// A zombie still answers signal 0 until its parent reaps it, so this waits for
+/// genuine `ESRCH` rather than treating "doomed" as "gone".
+#[cfg(unix)]
+async fn await_process_groups_reaped(
+    groups: &std::collections::HashSet<u32>,
+    deadline: Instant,
+) -> io::Result<()> {
+    use nix::errno::Errno;
+    use nix::sys::signal::killpg;
+    use nix::unistd::Pid;
+
+    if groups.is_empty() {
+        return Ok(());
+    }
+    loop {
+        let still_alive = groups
+            .iter()
+            .copied()
+            .filter_map(|id| i32::try_from(id).ok())
+            .any(|id| !matches!(killpg(Pid::from_raw(id), None), Err(Errno::ESRCH)));
+        if !still_alive {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(process_tree_shutdown_timeout());
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+/// Windows tears the tree down synchronously via `taskkill /T /F`, which has
+/// already returned by the time the registry drains, so there is no equivalent
+/// window to wait out.
+#[cfg(not(unix))]
+async fn await_process_groups_reaped(
+    _groups: &std::collections::HashSet<u32>,
+    _deadline: Instant,
+) -> io::Result<()> {
+    Ok(())
 }
 
 fn process_tree_shutdown_timeout() -> io::Error {

--- a/apps/desktop/src/features/code/FileTree.tsx
+++ b/apps/desktop/src/features/code/FileTree.tsx
@@ -88,6 +88,10 @@ export function FileTree({ rootPath, onFileSelect, selectedFile, className }: Fi
     debouncedSearch(searchInput);
   }, [searchInput, debouncedSearch]);
 
+  // The trailing timer outlives the component otherwise, and fires
+  // setDebouncedSearchQuery against an unmounted tree.
+  useEffect(() => () => debouncedSearch.cancel(), [debouncedSearch]);
+
   const fetchDirectoryEntries = useCallback(async (path: string) => {
     const entries = await invoke<
       {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "sync:models:check": "pnpm --filter @agiworkforce/model-registry check",
     "sync:models:refresh": "pnpm --filter @agiworkforce/model-registry refresh",
     "check:lock-drift": "node scripts/check-lock-build-drift.mjs",
-    "check:llm-operability": "pnpm check:agent-context && pnpm check:audit-inventory && pnpm check:capability-gaps && pnpm check:ui-gaps && pnpm check:executable-docs && pnpm check:agent-context-indexes && pnpm check:repo-organization && pnpm check:workspace-scripts && pnpm check:boundaries && pnpm check:cloud-contract-ownership && pnpm check:artifact-sync-ownership && pnpm check:service-domain-ownership && pnpm check:module-reachability && pnpm check:surface-reachability && pnpm check:surface-invariants && pnpm check:structure-conventions && pnpm check:mobile-hygiene && pnpm check:env-contract && pnpm check:service-layer && pnpm check:lane-ownership && pnpm check:generated-artifacts && pnpm sync:models:check && pnpm check:report-retention && pnpm check:non-md-artifacts && pnpm check:neon-migrations && pnpm check:ci-guardrails && pnpm check:codeowners && pnpm check:readme-ownership && pnpm check:doc-status && pnpm check:hooks && pnpm check:hook-fire-sites && pnpm check:model-catalog && pnpm check:availability-invariant && pnpm check:db-isolation && pnpm check:css-tokens && pnpm check:llm-failures",
+    "check:llm-operability": "pnpm check:agent-context && pnpm check:audit-inventory && pnpm check:capability-gaps && pnpm check:ui-gaps && pnpm check:executable-docs && pnpm check:agent-context-indexes && pnpm check:repo-organization && pnpm check:workspace-scripts && pnpm check:boundaries && pnpm check:cloud-contract-ownership && pnpm check:artifact-sync-ownership && pnpm check:service-domain-ownership && pnpm check:module-reachability && pnpm check:surface-reachability && pnpm check:surface-invariants && pnpm check:structure-conventions && pnpm check:mobile-hygiene && pnpm check:env-contract && pnpm check:service-layer && pnpm check:lane-ownership && pnpm check:generated-artifacts && pnpm sync:models:check && pnpm check:report-retention && pnpm check:non-md-artifacts && pnpm check:neon-migrations && pnpm check:ci-guardrails && pnpm check:workflow-cargo-features && pnpm check:codeowners && pnpm check:readme-ownership && pnpm check:doc-status && pnpm check:hooks && pnpm check:hook-fire-sites && pnpm check:model-catalog && pnpm check:availability-invariant && pnpm check:db-isolation && pnpm check:css-tokens && pnpm check:llm-failures",
     "audit:file-ledger": "node scripts/generate-surface-file-ledger.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -173,7 +173,8 @@
     "check:db-isolation": "node scripts/check-db-isolation.mjs",
     "check:css-tokens": "node scripts/check-css-tokens.mjs",
     "check:knip": "knip",
-    "check:knip:production": "knip --production"
+    "check:knip:production": "knip --production",
+    "check:workflow-cargo-features": "node scripts/check-workflow-cargo-features.mjs"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",

--- a/packages/platform/utils/src/__tests__/async.debounce.test.ts
+++ b/packages/platform/utils/src/__tests__/async.debounce.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { debounce } from '../async';
+
+describe('debounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('runs the trailing call once after the quiet period', () => {
+    const spy = vi.fn();
+    const debounced = debounce(spy, 300);
+
+    debounced('a');
+    debounced('ab');
+    debounced('abc');
+    expect(spy).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(300);
+    expect(spy).toHaveBeenCalledExactlyOnceWith('abc');
+  });
+
+  it('cancel() drops the pending call so it can never fire', () => {
+    // This is the unmount contract. Without it a debounced state setter fires
+    // against a torn-down React tree — in jsdom that surfaces as an uncaught
+    // `window is not defined` from resolveUpdatePriority, attributed to
+    // whichever test file happened to be running when the timer expired.
+    const spy = vi.fn();
+    const debounced = debounce(spy, 300);
+
+    debounced('pending');
+    debounced.cancel();
+
+    vi.advanceTimersByTime(10_000);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('cancel() is idempotent and safe after the call already fired', () => {
+    const spy = vi.fn();
+    const debounced = debounce(spy, 300);
+
+    debounced('a');
+    vi.advanceTimersByTime(300);
+    expect(spy).toHaveBeenCalledOnce();
+
+    expect(() => {
+      debounced.cancel();
+      debounced.cancel();
+    }).not.toThrow();
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it('accepts new calls after a cancel', () => {
+    const spy = vi.fn();
+    const debounced = debounce(spy, 300);
+
+    debounced('dropped');
+    debounced.cancel();
+    debounced('kept');
+
+    vi.advanceTimersByTime(300);
+    expect(spy).toHaveBeenCalledExactlyOnceWith('kept');
+  });
+});

--- a/packages/platform/utils/src/async.ts
+++ b/packages/platform/utils/src/async.ts
@@ -80,9 +80,17 @@ export function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> 
  * The debounced function will only execute after the specified delay
  * has passed without any new calls.
  *
+ * The returned function carries `cancel()`, which drops any pending call. A
+ * debounced callback that closes over component state MUST be cancelled on
+ * unmount: otherwise the trailing timer fires against a torn-down tree. In
+ * production that is a React "update on an unmounted component"; under jsdom
+ * it is an uncaught `ReferenceError: window is not defined` thrown from
+ * `resolveUpdatePriority` well after the owning test finished, which fails the
+ * whole run and blames an unrelated file.
+ *
  * @param func - Function to debounce
  * @param wait - Delay in milliseconds
- * @returns Debounced function
+ * @returns Debounced function with a `cancel()` method
  *
  * @example
  * ```typescript
@@ -95,13 +103,19 @@ export function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> 
  * debouncedSearch('abc'); // Only this one executes after 300ms
  * ```
  */
+export interface DebouncedFunction<TArgs extends unknown[]> {
+  (...args: TArgs): void;
+  /** Drop any pending call. Idempotent, and safe to call after it has fired. */
+  cancel(): void;
+}
+
 export function debounce<TArgs extends unknown[], TReturn>(
   func: (...args: TArgs) => TReturn,
   wait: number,
-): (...args: TArgs) => void {
+): DebouncedFunction<TArgs> {
   let timeout: ReturnType<typeof setTimeout> | null = null;
 
-  return function executedFunction(...args: TArgs) {
+  const executedFunction = function (...args: TArgs) {
     const later = () => {
       timeout = null;
       func(...args);
@@ -111,7 +125,16 @@ export function debounce<TArgs extends unknown[], TReturn>(
       clearTimeout(timeout);
     }
     timeout = setTimeout(later, wait);
+  } as DebouncedFunction<TArgs>;
+
+  executedFunction.cancel = () => {
+    if (timeout !== null) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
   };
+
+  return executedFunction;
 }
 
 /**

--- a/scripts/check-workflow-cargo-features.mjs
+++ b/scripts/check-workflow-cargo-features.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Verify every `--features "crate/feature"` a workflow passes to cargo names a
+ * feature that actually exists.
+ *
+ * WHY. `Clippy (all features)` passed `agiworkforce-desktop/sentry`, and that
+ * feature does not exist. Cargo rejects an unknown feature during argument
+ * parsing:
+ *
+ *   error: none of the selected packages contains this feature:
+ *          agiworkforce-desktop/sentry
+ *
+ * so the lane failed on every commit while linting ZERO lines. It stayed
+ * invisible for weeks because the job only runs after `check` passes, and
+ * `check` was red from 2026-07-21 until it was fixed.
+ *
+ * That is the shape worth guarding: a gate that dies during argument parsing
+ * is indistinguishable from one that has nothing to report. Neither ever says
+ * "I linted nothing" — one is simply red, and a permanently red lane stops
+ * being read.
+ *
+ * This is a text check on purpose. It costs milliseconds and needs no cargo,
+ * no toolchain and no network, so it runs in the ordinary guard chain rather
+ * than only where Rust is installed.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const root = process.cwd();
+const WORKFLOWS = path.join(root, '.github/workflows');
+const SKIP_DIRS = new Set(['node_modules', 'target', 'dist', '.git', '.next']);
+
+/** crate name -> Set of declared feature names, from every Cargo.toml. */
+function crateFeatures() {
+  const manifests = new Map();
+
+  function walk(dir, depth) {
+    if (depth > 4) return;
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.') || SKIP_DIRS.has(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full, depth + 1);
+      } else if (entry.name === 'Cargo.toml') {
+        let src;
+        try {
+          src = fs.readFileSync(full, 'utf8');
+        } catch {
+          continue;
+        }
+        const name = /^name\s*=\s*"([^"]+)"/m.exec(src)?.[1];
+        if (!name) continue;
+        const features = new Set();
+        // Capture to the NEXT section header, or end of file. An earlier
+        // version ended the capture at /^\[|\s*$/m, whose second alternative
+        // matches at the first line end under the m flag — so it captured
+        // nothing and every real feature was reported missing. Caught by
+        // running this guard against the known-good config before trusting it.
+        const block = /^\[features\]\r?\n([\s\S]*?)(?=^\[[A-Za-z]|$(?![\s\S]))/m.exec(src);
+        if (block) {
+          for (const line of block[1].split('\n')) {
+            const key = /^([A-Za-z0-9_-]+)\s*=/.exec(line)?.[1];
+            if (key) features.add(key);
+          }
+        }
+        // An optional dependency implicitly declares a feature of the same
+        // name, so `dep:foo`-style features are not the only valid values.
+        for (const dep of src.matchAll(/^([A-Za-z0-9_-]+)\s*=\s*\{[^}]*optional\s*=\s*true/gm)) {
+          features.add(dep[1]);
+        }
+        manifests.set(name, features);
+      }
+    }
+  }
+
+  walk(root, 0);
+  return manifests;
+}
+
+const manifests = crateFeatures();
+const errors = [];
+let referenceCount = 0;
+
+let workflowFiles = [];
+try {
+  workflowFiles = fs
+    .readdirSync(WORKFLOWS)
+    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
+} catch {
+  console.log('No .github/workflows directory; nothing to check.');
+  process.exit(0);
+}
+
+for (const file of workflowFiles) {
+  const src = fs.readFileSync(path.join(WORKFLOWS, file), 'utf8');
+  for (const match of src.matchAll(/--features\s+"([^"]+)"/g)) {
+    for (const spec of match[1]
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)) {
+      if (!spec.includes('/')) continue; // bare feature: belongs to the current crate
+      referenceCount += 1;
+      const [crate, feature] = spec.split('/');
+      const declared = manifests.get(crate);
+      if (!declared) {
+        errors.push(
+          `${file}: --features names crate '${crate}', which has no Cargo.toml in this workspace.`,
+        );
+        continue;
+      }
+      if (!declared.has(feature)) {
+        const known = [...declared].sort().join(', ') || '(none)';
+        errors.push(
+          `${file}: '${crate}' has no feature '${feature}'.\n` +
+            `    cargo rejects this during argument parsing, so the step fails ` +
+            `without linting or building anything.\n` +
+            `    Declared features: ${known}`,
+        );
+      }
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Workflow cargo-feature check failed:\n');
+  for (const error of errors) console.error(`- ${error}\n`);
+  process.exit(1);
+}
+
+console.log(
+  `Workflow cargo-feature check passed (${referenceCount} qualified reference(s) across ` +
+    `${workflowFiles.length} workflow(s), against ${manifests.size} crate(s)).`,
+);


### PR DESCRIPTION
Unblocks CI, which has failed **100 consecutive runs** since 2026-07-21.

All 100 reduce to one test out of 1,838:
```
app_server::developer_host::tests::shutdown_waits_for_a_running_turns_grandchild_tree_before_acknowledging
panicked: shutdown acknowledged while its process tree still existed
```

Every E2E job declares `needs: check`, and `deploy-production.yml` is `workflow_run`-gated on CI success — so this single test has blocked every end-to-end job and every verified deploy for 18 days. The last 28 deploy runs show conclusion `skipped`.

### It is a real race, not a flaky assertion

`terminate_owners_and_wait` returned as soon as the in-process registry drained. A registry entry disappears when the supervisor drops the tracked child — the **direct** child exiting, not the group being reaped. `killpg(SIGKILL)` is delivered asynchronously, so between those two moments the grandchildren are doomed but still present. `shutdown()` acknowledged while its tree was alive, which is exactly what its name promises it will not do.

Idle machine: passes 5/5 locally in isolation. Under CI load alongside 1,833 other tests, the window is wide enough to lose.

### Fix

After the registry drains, poll the signalled groups until `killpg` reports `ESRCH`, bounded by the existing deadline. A zombie still answers signal 0 until reaped, so this waits for genuine absence rather than treating "doomed" as "gone". Windows unchanged — `taskkill /T /F` is synchronous.

Verified: full suite 1,837 passed, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process-tree shutdown reliability by waiting for the operating system to confirm that terminated process groups have been fully reaped.
  * Added timeout-aware handling to prevent shutdown from hanging indefinitely.
  * Preserved immediate shutdown behavior on platforms where process termination is synchronous.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->