### PR TITLE
fix(web): restore the authenticated api by tracing argon2 into the bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -628,6 +628,22 @@ jobs:
       NEON_DATABASE_URL: postgres://postgres:postgres@localhost:5432/agiworkforce_test
       CLERK_SECRET_KEY: test-clerk-secret-key
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_mock
+      # `instrumentation.ts` runs validate-env at boot and throws on a missing
+      # critical variable, so without these the server never starts and every
+      # E2E and accessibility assertion fails against a dead port — which is
+      # exactly what this lane had been doing.
+      #
+      # Placeholders rather than AGI_ALLOW_INVALID_ENV=1: the checks are
+      # presence-only (apps/web/lib/validate-env.ts), no Stripe call is made in
+      # this lane, and naming each variable keeps the validator meaningful. A
+      # newly required variable still fails this job loudly instead of being
+      # silently suppressed by a blanket override.
+      STRIPE_SECRET_KEY: sk_test_ci_placeholder
+      STRIPE_WEBHOOK_SECRET: whsec_ci_placeholder
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: pk_test_ci_placeholder
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+      STRIPE_PRICE_PRO_MONTHLY: price_ci_placeholder_pro_monthly
+      STRIPE_PRICE_PRO_YEARLY: price_ci_placeholder_pro_yearly
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -579,6 +579,15 @@ jobs:
       - name: Install Detox simulator utilities
         run: |
           brew tap wix/brew
+          # Homebrew now refuses formulae from third-party taps unless the tap
+          # is explicitly trusted:
+          #   "Refusing to load formula wix/brew/applesimutils from untrusted
+          #    tap wix/brew. Run `brew trust wix/brew` to trust it."
+          # applesimutils is Detox's own simulator helper and wix/brew is the
+          # Detox authors' tap, which is why it was already tapped above. The
+          # trust step just makes the existing decision explicit to the newer
+          # Homebrew. Without it this job dies before a single test runs.
+          brew trust wix/brew
           brew install applesimutils
           pnpm --filter @agiworkforce/mobile exec detox build-framework-cache
 

--- a/.vercelignore
+++ b/.vercelignore
@@ -102,3 +102,20 @@ lerna-debug.log
 
 # Vercel specific
 .vercel
+
+# Native and platform build outputs (2026-08-08)
+#
+# `vercel --prod` uploads the working directory. Without these the CLI tries to
+# push ~1.2GB and dies on "File size limit exceeded (100 MB)" — which is why a
+# CLI deploy was not a usable incident-response path during the argon2 outage.
+# None of it is an input to the web build.
+target
+apps/desktop/release
+apps/desktop/src-tauri/target
+apps/extension-vscode/.vscode-test
+apps/extension-vscode/*.vsix
+apps/mobile/ios/Pods
+apps/mobile/android/.gradle
+apps/mobile/android/app/build
+tmp
+.turbo/cache

--- a/.vercelignore
+++ b/.vercelignore
@@ -105,9 +105,9 @@ lerna-debug.log
 
 # Native and platform build outputs (2026-08-08)
 #
-# `vercel --prod` uploads the working directory. Without these the CLI tries to
-# push ~1.2GB and dies on "File size limit exceeded (100 MB)" — which is why a
-# CLI deploy was not a usable incident-response path during the argon2 outage.
+# A CLI production deploy uploads the working directory. Without these the CLI
+# tries to push ~1.2GB and dies on "File size limit exceeded (100 MB)" — which
+# is why it was not a usable incident-response path during the argon2 outage.
 # None of it is an input to the web build.
 target
 apps/desktop/release

--- a/apps/web/lib/api-auth.ts
+++ b/apps/web/lib/api-auth.ts
@@ -4,7 +4,13 @@ import type { NextRequest } from 'next/server';
 import { createError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
 import { auth } from '@clerk/nextjs/server';
-import { ApiKeyService } from '@/lib/services/api-key-service';
+// NOT a static import. `ApiKeyService` pulls in `argon2`, a native module, at
+// module scope — and 98 route files import this one. On 2026-08-07 that binary
+// failed to resolve in the serverless bundle and every one of those routes
+// returned an empty 500 for ~21 hours, including routes that never hash
+// anything. Importing it lazily, only on the API-key path, means a hashing
+// dependency can fail without taking the authenticated surface with it.
+// See the incident note in apps/web/next.config.ts.
 import { getNeonDb } from '@/lib/server/neon-db';
 import {
   isDeveloperTokenRevoked,
@@ -171,6 +177,7 @@ async function verifyApiKey(
   token: string,
 ): Promise<(AuthResult & { scopes: readonly string[] }) | null> {
   try {
+    const { ApiKeyService } = await import('@/lib/services/api-key-service');
     const apiKey = await ApiKeyService.verifyKey(token);
     if (!apiKey) return null;
     return { userId: apiKey.user_id, scopes: apiKey.scopes };

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -38,6 +38,33 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: false,
   },
+  /**
+   * INCIDENT 2026-08-07 → 2026-08-08: every authenticated API route returned an
+   * empty HTTP 500 for ~21 hours.
+   *
+   *   Failed to load external module argon2-…: No native build was found for
+   *   platform=linux arch=arm64 abi=137 node=24.18.0
+   *
+   * `argon2` ships real prebuilt binaries (`prebuildify --napi`, including
+   * `prebuilds/linux-arm64/`), and N-API is ABI-stable, so the reported `abi=137`
+   * was a symptom rather than the cause. The cause is that `node-gyp-build`
+   * locates those `.node` files by BUILDING A PATH AT RUNTIME. Next's static file
+   * tracing cannot see a path that does not exist as a literal import, so the
+   * binaries were never copied into the serverless bundle.
+   *
+   * `serverExternalPackages` stops the bundler inlining the package;
+   * `outputFileTracingIncludes` copies the prebuilds it cannot infer. Both are
+   * required — either alone still ships a package that cannot resolve its binary.
+   *
+   * Blast radius was 98 route files, because `lib/api-auth.ts` imports
+   * `ApiKeyService`, which imports `argon2` at module scope. That import is being
+   * made lazy in the same change so a hashing dependency can never again take
+   * down routes that do no hashing.
+   */
+  serverExternalPackages: ['argon2'],
+  outputFileTracingIncludes: {
+    '/api/**/*': ['../../node_modules/.pnpm/argon2@*/node_modules/argon2/prebuilds/**'],
+  },
   // Instrumentation is automatically enabled in Next.js 16+
   // See: apps/web/instrumentation.ts
   experimental: {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "sync:models:check": "pnpm --filter @agiworkforce/model-registry check",
     "sync:models:refresh": "pnpm --filter @agiworkforce/model-registry refresh",
     "check:lock-drift": "node scripts/check-lock-build-drift.mjs",
-    "check:llm-operability": "pnpm check:agent-context && pnpm check:audit-inventory && pnpm check:capability-gaps && pnpm check:ui-gaps && pnpm check:executable-docs && pnpm check:agent-context-indexes && pnpm check:repo-organization && pnpm check:workspace-scripts && pnpm check:boundaries && pnpm check:cloud-contract-ownership && pnpm check:artifact-sync-ownership && pnpm check:service-domain-ownership && pnpm check:module-reachability && pnpm check:surface-reachability && pnpm check:surface-invariants && pnpm check:structure-conventions && pnpm check:mobile-hygiene && pnpm check:env-contract && pnpm check:service-layer && pnpm check:lane-ownership && pnpm check:generated-artifacts && pnpm sync:models:check && pnpm check:report-retention && pnpm check:non-md-artifacts && pnpm check:neon-migrations && pnpm check:ci-guardrails && pnpm check:codeowners && pnpm check:readme-ownership && pnpm check:doc-status && pnpm check:hooks && pnpm check:hook-fire-sites && pnpm check:model-catalog && pnpm check:availability-invariant && pnpm check:db-isolation && pnpm check:css-tokens && pnpm check:llm-failures",
+    "check:llm-operability": "pnpm check:agent-context && pnpm check:audit-inventory && pnpm check:capability-gaps && pnpm check:ui-gaps && pnpm check:executable-docs && pnpm check:agent-context-indexes && pnpm check:repo-organization && pnpm check:workspace-scripts && pnpm check:boundaries && pnpm check:cloud-contract-ownership && pnpm check:artifact-sync-ownership && pnpm check:service-domain-ownership && pnpm check:module-reachability && pnpm check:surface-reachability && pnpm check:surface-invariants && pnpm check:structure-conventions && pnpm check:mobile-hygiene && pnpm check:env-contract && pnpm check:service-layer && pnpm check:lane-ownership && pnpm check:generated-artifacts && pnpm check:native-module-tracing && pnpm sync:models:check && pnpm check:report-retention && pnpm check:non-md-artifacts && pnpm check:neon-migrations && pnpm check:ci-guardrails && pnpm check:codeowners && pnpm check:readme-ownership && pnpm check:doc-status && pnpm check:hooks && pnpm check:hook-fire-sites && pnpm check:model-catalog && pnpm check:availability-invariant && pnpm check:db-isolation && pnpm check:css-tokens && pnpm check:llm-failures",
     "audit:file-ledger": "node scripts/generate-surface-file-ledger.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -173,7 +173,8 @@
     "check:db-isolation": "node scripts/check-db-isolation.mjs",
     "check:css-tokens": "node scripts/check-css-tokens.mjs",
     "check:knip": "knip",
-    "check:knip:production": "knip --production"
+    "check:knip:production": "knip --production",
+    "check:native-module-tracing": "node --test scripts/check-native-module-tracing.test.mjs && node scripts/check-native-module-tracing.mjs"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",

--- a/scripts/check-native-module-tracing.mjs
+++ b/scripts/check-native-module-tracing.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * Prevention gate for the class of failure that took the authenticated API
+ * down on 2026-08-07.
+ *
+ * `argon2` resolves its `.node` binary at RUNTIME through `node-gyp-build`,
+ * which constructs the path from `process.arch`/`process.platform` rather than
+ * requiring it statically. Next's file tracer follows static requires, so it
+ * saw nothing to copy and shipped a serverless bundle with no binary in it.
+ * Every route that transitively imported the hashing code — 98 of them —
+ * answered HTTP 500:
+ *
+ *   Failed to load external module argon2-…: No native build was found for
+ *   platform=linux arch=arm64 abi=137 node=24.18.0
+ *
+ * The build SUCCEEDED. Type checking, linting and 6,500 unit tests all passed.
+ * Nothing in the pipeline could observe the difference, because the difference
+ * only exists in the deployed bundle. That is what makes this worth a
+ * dedicated check rather than a lesson learned.
+ *
+ * Two declarations are required and NEITHER is sufficient alone:
+ *   - `serverExternalPackages` stops the bundler inlining the package;
+ *   - `outputFileTracingIncludes` copies the binary the tracer cannot infer.
+ *
+ * This asserts both exist for every native package the web server actually
+ * imports. It is static and takes milliseconds, so it runs in the guard chain
+ * rather than waiting for a deploy to fail.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const root = process.cwd();
+const WEB = path.join(root, 'apps/web');
+const CONFIG = path.join(WEB, 'next.config.ts');
+const STORE = path.join(root, 'node_modules/.pnpm');
+
+/** Directories whose code runs on the server and can pull in a native module. */
+const SERVER_DIRS = ['app', 'lib', 'features', 'shared'];
+const SERVER_FILES = ['proxy.ts', 'instrumentation.ts'];
+const SOURCE_EXT = new Set(['.ts', '.tsx', '.mts', '.cts']);
+
+const errors = [];
+const notes = [];
+
+/** Every package in the pnpm store that ships a compiled binary. */
+function nativePackages() {
+  const found = new Set();
+  if (!fs.existsSync(STORE)) return found;
+  for (const entry of fs.readdirSync(STORE)) {
+    const base = path.join(STORE, entry, 'node_modules');
+    if (!fs.existsSync(base)) continue;
+    let top;
+    try {
+      top = fs.readdirSync(base);
+    } catch {
+      continue;
+    }
+    for (const pkg of top) {
+      const names = [];
+      if (pkg.startsWith('@')) {
+        try {
+          for (const sub of fs.readdirSync(path.join(base, pkg))) names.push(`${pkg}/${sub}`);
+        } catch {
+          continue;
+        }
+      } else {
+        names.push(pkg);
+      }
+      for (const name of names) {
+        const dir = path.join(base, name);
+        try {
+          if (
+            fs.existsSync(path.join(dir, 'prebuilds')) ||
+            fs.existsSync(path.join(dir, 'build', 'Release'))
+          ) {
+            found.add(name);
+          }
+        } catch {
+          /* unreadable entry in the store is not this check's business */
+        }
+      }
+    }
+  }
+  return found;
+}
+
+function* sourceFiles(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === '.next') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* sourceFiles(full);
+    } else if (SOURCE_EXT.has(path.extname(entry.name))) {
+      yield full;
+    }
+  }
+}
+
+/** Packages from `candidates` that web server source imports directly. */
+function importedNativePackages(candidates) {
+  const imported = new Map();
+  const files = [
+    ...SERVER_DIRS.flatMap((d) => [...sourceFiles(path.join(WEB, d))]),
+    ...SERVER_FILES.map((f) => path.join(WEB, f)).filter((f) => fs.existsSync(f)),
+  ];
+  for (const file of files) {
+    let src;
+    try {
+      src = fs.readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    for (const pkg of candidates) {
+      // Static import, dynamic import, or require of the package root or a
+      // subpath. A lazy `await import()` still needs the binary present.
+      const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const re = new RegExp(`(?:from|import|require)\\s*\\(?\\s*['"]${escaped}(?:/[^'"]*)?['"]`);
+      if (re.test(src)) {
+        if (!imported.has(pkg)) imported.set(pkg, []);
+        imported.get(pkg).push(path.relative(root, file));
+      }
+    }
+  }
+  return imported;
+}
+
+/**
+ * Strip comments before matching.
+ *
+ * Found by testing this check against the real outage: with
+ * `outputFileTracingIncludes` DELETED from the config, the check still passed,
+ * because the identifier appears in the doc comment above it and `argon2` sat
+ * within the search window. The guard was matching prose. A check that passes
+ * for the wrong reason is worse than no check, because it is trusted.
+ */
+function stripComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+const config = fs.existsSync(CONFIG) ? stripComments(fs.readFileSync(CONFIG, 'utf8')) : '';
+if (!config) {
+  errors.push(`Missing ${path.relative(root, CONFIG)} — cannot verify native-module tracing.`);
+}
+
+const candidates = nativePackages();
+const imported = importedNativePackages(candidates);
+
+for (const [pkg, files] of [...imported].sort(([a], [b]) => a.localeCompare(b))) {
+  const declaredExternal = new RegExp(
+    `serverExternalPackages[\\s\\S]{0,400}?['"]${pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]`,
+  ).test(config);
+  const declaredTraced = new RegExp(
+    `outputFileTracingIncludes[\\s\\S]{0,800}?${pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
+  ).test(config);
+
+  if (!declaredExternal || !declaredTraced) {
+    const missing = [
+      !declaredExternal ? 'serverExternalPackages' : null,
+      !declaredTraced ? 'outputFileTracingIncludes' : null,
+    ]
+      .filter(Boolean)
+      .join(' and ');
+    errors.push(
+      `'${pkg}' ships a native binary and is imported by the web server, but is missing from ` +
+        `${missing} in apps/web/next.config.ts.\n` +
+        `    Imported by: ${files.slice(0, 3).join(', ')}${files.length > 3 ? ` (+${files.length - 3} more)` : ''}\n` +
+        `    Both declarations are required. Either alone still ships a package that cannot ` +
+        `resolve its binary at runtime, which builds green and 500s in production.`,
+    );
+  } else {
+    notes.push(`${pkg}: declared external and traced (${files.length} importing file(s))`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Native-module tracing check failed:\n');
+  for (const error of errors) console.error(`- ${error}\n`);
+  process.exit(1);
+}
+
+console.log(
+  `Native-module tracing check passed (${candidates.size} native package(s) in the store, ` +
+    `${imported.size} imported by the web server).`,
+);
+for (const note of notes) console.log(`  ${note}`);

--- a/scripts/check-native-module-tracing.test.mjs
+++ b/scripts/check-native-module-tracing.test.mjs
@@ -1,0 +1,76 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT = path.join(root, 'scripts/check-native-module-tracing.mjs');
+const CONFIG = path.join(root, 'apps/web/next.config.ts');
+
+/**
+ * Run the real check against a temporarily modified next.config.ts.
+ *
+ * The check reads the actual pnpm store and the actual web sources, so these
+ * exercise the same code path CI runs rather than a stubbed approximation.
+ * The config is always restored, including on failure.
+ */
+function withConfig(transform) {
+  const original = fs.readFileSync(CONFIG, 'utf8');
+  const backup = path.join(os.tmpdir(), `next.config.${process.pid}.bak.ts`);
+  fs.writeFileSync(backup, original);
+  try {
+    fs.writeFileSync(CONFIG, transform(original));
+    try {
+      execFileSync('node', [SCRIPT], { cwd: root, stdio: 'pipe' });
+      return { ok: true, output: '' };
+    } catch (error) {
+      return {
+        ok: false,
+        output: `${error.stdout ?? ''}${error.stderr ?? ''}`,
+      };
+    }
+  } finally {
+    fs.writeFileSync(CONFIG, fs.readFileSync(backup, 'utf8'));
+    fs.rmSync(backup, { force: true });
+  }
+}
+
+test('passes on the committed configuration', () => {
+  const result = withConfig((s) => s);
+  assert.ok(result.ok, `check should pass as committed:\n${result.output}`);
+});
+
+test('fails when serverExternalPackages loses the native package', () => {
+  const result = withConfig((s) => s.replace("  serverExternalPackages: ['argon2'],\n", ''));
+  assert.ok(!result.ok, 'removing serverExternalPackages must fail the check');
+  assert.match(result.output, /serverExternalPackages/);
+});
+
+test('fails when outputFileTracingIncludes loses the native package', () => {
+  // THE REGRESSION THIS TEST EXISTS FOR. The first version of the check passed
+  // here, because `outputFileTracingIncludes` also appears in the doc comment
+  // above the config and `argon2` fell inside the search window — the guard
+  // was matching prose, not configuration. This is the half-fix that still
+  // 500s in production, so it has to fail.
+  const result = withConfig((s) => s.replace(/ {2}outputFileTracingIncludes: \{\n[^}]*\},\n/, ''));
+  assert.ok(!result.ok, 'removing outputFileTracingIncludes must fail the check');
+  assert.match(result.output, /outputFileTracingIncludes/);
+});
+
+test('fails when both declarations are absent, as they were during the outage', () => {
+  const result = withConfig((s) =>
+    s
+      .replace("  serverExternalPackages: ['argon2'],\n", '')
+      .replace(/ {2}outputFileTracingIncludes: \{\n[^}]*\},\n/, ''),
+  );
+  assert.ok(!result.ok, 'the pre-outage configuration must fail the check');
+});
+
+test('reports which files import the native package, so the fix is actionable', () => {
+  const result = withConfig((s) => s.replace("  serverExternalPackages: ['argon2'],\n", ''));
+  assert.match(result.output, /Imported by:/);
+  assert.match(result.output, /api-key-service\.ts/);
+});


### PR DESCRIPTION
**Production outage.** Every authenticated route on agiworkforce.com has returned an empty HTTP 500 since 2026-08-07 21:41 UTC. Confirmed against Vercel, not inferred: 262 occurrences across 24 routes, most recent 18:38 UTC today.

```
Failed to load external module argon2-…: No native build was found for
platform=linux arch=arm64 abi=137 node=24.18.0
```

Affected includes `/api/llm/v1/chat/completions`, `/api/me`, `/api/usage`, `/api/memory`, `/api/projects`, `/api/chat/sync`.

### Root cause

argon2 ships real prebuilt binaries and N-API is ABI-stable, so `abi=137` was a symptom. The cause is that `node-gyp-build` locates `.node` files by **building a path at runtime**, which Next's static file tracing cannot see — the binaries were never copied into the serverless bundle. `prebuilds/linux-arm64/argon2.armv8.glibc.node` is present in `node_modules`; it simply never shipped.

### Fix

`serverExternalPackages` stops the bundler inlining the package; `outputFileTracingIncludes` copies the prebuilds it cannot infer. Both are required — either alone still ships a package that cannot resolve its binary.

**Verified by building:** 197 route traces now contain the prebuilds, including the exact `linux-arm64/argon2.armv8.glibc.node` the error named. Before this change, zero did.

### Structural half

Blast radius was 98 route files, because `lib/api-auth.ts` imported `ApiKeyService` at module scope and that imports argon2 — so routes that never hash anything died with it. That import is now lazy and lives on the api-key path only.

Typecheck clean; 1,021 tests pass.

> Depends on #400 for CI to actually run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability for secure API-key verification, including Linux ARM64 environments.
  * Added post-deployment verification for authenticated routes to catch production issues earlier.
  * Updated automated mobile and web test setup with required tooling and configuration.

* **Chores**
  * Excluded native and generated build artifacts from Vercel deployments.
  * Added checks to detect missing native-module deployment configuration.

* **Tests**
  * Added coverage for successful and incomplete deployment configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->