### PR TITLE
fix(gateway): enforce rolling usage caps and bill abandoned streams

### DIFF
--- a/apps/web/lib/server/managed-usage-policy.ts
+++ b/apps/web/lib/server/managed-usage-policy.ts
@@ -1,229 +1,44 @@
 import 'server-only';
 
-import type { BillingInterval, BillingPlanTier } from '@agiworkforce/types';
-
-interface ManagedUsageLimit {
-  monthlyUnits: number;
-  weeklyUnits: number;
-  fiveHourUnits: number;
-  dailyUnits: number;
-  /**
-   * GOV-1: explicit "this tier has NO configured spend ceiling" marker.
-   *
-   * Before this flag every tier expressed "no cap" and "cap of zero" with the
-   * same value (0), and the SQL guard `p_*_cap_cents > 0` turned that single
-   * value into UNLIMITED. That inverted fail-closed: Enterprise (an all-zero
-   * row) had no rolling ceiling at all on the only durable usage gate.
-   *
-   * The two states are now distinct and the DEFAULT IS DENY:
-   *   unlimited: true  -> cap resolves to null -> SQL treats it as no ceiling
-   *   unlimited: false -> cap resolves to a number; 0 means "deny every
-   *                       reservation against this ledger", not "unlimited"
-   */
-  unlimited: boolean;
-}
-
 /**
- * A resolved rolling/period ceiling in paid-ledger cents.
- * `null` = explicitly uncapped (negotiated contract). A number is a hard
- * ceiling, and 0 denies every reservation.
- */
-export type ManagedUsageCapCents = number | null;
-
-/**
- * GOV-2: ledger allocation used for tiers whose contract carries no numeric
- * monthly allowance (Enterprise). The paid ledger still needs a real account —
- * `CreditService.checkAvailable` returns false without one, which hard-blocked
- * every Enterprise chat with "Usage budget exhausted. Upgrade your plan".
+ * The usage-ceiling policy moved to `@agiworkforce/types` on 2026-08-08.
  *
- * This is HEADROOM, NOT A PRICE OR A SPEND CEILING: an uncapped tier's actual
- * governor is its negotiated contract plus the rolling caps above (which
- * resolve to null for it). It exists only so the cents ledger has an account
- * to debit against.
- */
-export const MANAGED_USAGE_UNCAPPED_LEDGER_ALLOCATION_CENTS = 100_000_000;
-
-/**
- * Private managed-compute allowances. These values must never be serialized
- * into pricing, usage, or client configuration responses. Public clients get
- * percentages and reset times only.
- */
-const MANAGED_USAGE_LIMITS: Readonly<Record<BillingPlanTier, ManagedUsageLimit>> = Object.freeze({
-  // Local trust boundary: never admitted to managed compute. Zero WITHOUT the
-  // unlimited marker now means deny, which is what these tiers must get.
-  'local-only': {
-    monthlyUnits: 0,
-    weeklyUnits: 0,
-    fiveHourUnits: 0,
-    dailyUnits: 0,
-    unlimited: false,
-  },
-  byok: { monthlyUnits: 0, weeklyUnits: 0, fiveHourUnits: 0, dailyUnits: 0, unlimited: false },
-  // Free's allowance is real but lives in the separate micro-USD reservation
-  // ledger; against the PAID cents ledger its cap is 0 = deny.
-  free: { monthlyUnits: 20, weeklyUnits: 15, fiveHourUnits: 5, dailyUnits: 0, unlimited: false },
-  basic: {
-    monthlyUnits: 400,
-    weeklyUnits: 100,
-    fiveHourUnits: 20,
-    dailyUnits: 0,
-    unlimited: false,
-  },
-  pro: {
-    monthlyUnits: 2_000,
-    weeklyUnits: 500,
-    fiveHourUnits: 100,
-    dailyUnits: 0,
-    unlimited: false,
-  },
-  max: {
-    monthlyUnits: 10_000,
-    weeklyUnits: 2_500,
-    fiveHourUnits: 500,
-    dailyUnits: 0,
-    unlimited: false,
-  },
-  max_15x: {
-    monthlyUnits: 30_000,
-    weeklyUnits: 7_500,
-    fiveHourUnits: 1_500,
-    dailyUnits: 0,
-    unlimited: false,
-  },
-  team: {
-    monthlyUnits: 2_000,
-    weeklyUnits: 500,
-    fiveHourUnits: 100,
-    dailyUnits: 0,
-    unlimited: false,
-  },
-  // Negotiated contract: DELIBERATELY uncapped, declared rather than inferred
-  // from a zero. Its spend governor is the contract, not this table.
-  enterprise: {
-    monthlyUnits: 0,
-    weeklyUnits: 0,
-    fiveHourUnits: 0,
-    dailyUnits: 0,
-    unlimited: true,
-  },
-});
-
-const INTERNAL_USAGE_UNITS_PER_LEDGER_CENT = 2;
-const MICROUSD_PER_INTERNAL_USAGE_UNIT = 5_000;
-const FLAGSHIP_OF_WEEKLY_BUDGET_RATIO = 0.3;
-
-/** Convert private server ledger values to the only public numeric usage value. */
-export function toPublicUsagePercentage(used: number, limit: number): number {
-  if (limit <= 0) return 0;
-  const boundedUsed = Math.min(limit, Math.max(0, used));
-  return Math.round((boundedUsed / limit) * 10_000) / 100;
-}
-
-function getLimit(plan: string | null | undefined): ManagedUsageLimit | null {
-  if (!plan) return null;
-  const normalized = plan.trim().toLowerCase() as BillingPlanTier;
-  return Object.prototype.hasOwnProperty.call(MANAGED_USAGE_LIMITS, normalized)
-    ? MANAGED_USAGE_LIMITS[normalized]
-    : null;
-}
-
-export function getPlanMonthlyUsageUnits(plan: string | null | undefined): number {
-  return getLimit(plan)?.monthlyUnits ?? 0;
-}
-
-export function getPlanWeeklyUsageUnits(plan: string | null | undefined): number {
-  return getLimit(plan)?.weeklyUnits ?? 0;
-}
-
-export function getPlanDailyUsageUnits(plan: string | null | undefined): number {
-  return getLimit(plan)?.dailyUnits ?? 0;
-}
-
-export function getPlanFiveHourUsageUnits(plan: string | null | undefined): number {
-  return getLimit(plan)?.fiveHourUnits ?? 0;
-}
-
-export function getPlanMonthlyUsageBudgetMicrousd(plan: string | null | undefined): number {
-  return getPlanMonthlyUsageUnits(plan) * MICROUSD_PER_INTERNAL_USAGE_UNIT;
-}
-
-export function getPlanWeeklyUsageBudgetMicrousd(plan: string | null | undefined): number {
-  return getPlanWeeklyUsageUnits(plan) * MICROUSD_PER_INTERNAL_USAGE_UNIT;
-}
-
-export function getPlanFiveHourUsageBudgetMicrousd(plan: string | null | undefined): number {
-  return getPlanFiveHourUsageUnits(plan) * MICROUSD_PER_INTERNAL_USAGE_UNIT;
-}
-
-export function getInternalUsageUnitMicrousd(): number {
-  return MICROUSD_PER_INTERNAL_USAGE_UNIT;
-}
-
-function unitsToLedgerCents(units: number): number {
-  if (units <= 0) return 0;
-  if (units % INTERNAL_USAGE_UNITS_PER_LEDGER_CENT !== 0) {
-    throw new Error('Managed usage allocation cannot be represented by the paid cents ledger');
-  }
-  return units / INTERNAL_USAGE_UNITS_PER_LEDGER_CENT;
-}
-
-/** GOV-1: whether `plan` is declared as having no configured spend ceiling. */
-export function isPlanUsageUncapped(plan: string | null | undefined): boolean {
-  return getLimit(plan)?.unlimited === true;
-}
-
-/**
- * Paid billing-period allocation for the existing cents ledger.
+ * It sat behind `import 'server-only'`, which made it unreachable from
+ * `services/api-gateway` — so the gateway reserved with NO rolling ceilings and
+ * every developer surface (desktop, CLI, VS Code) enforced no five-hour, weekly
+ * or flagship limit. One definition, both surfaces, is the fix.
  *
- * GOV-2: an uncapped tier resolves to real ledger headroom instead of 0, so
- * `allocateCreditsForPeriod` actually creates its credit account and
- * `CreditService.checkAvailable` stops 402-ing the highest-paying tier.
+ * Everything is re-exported here so existing imports from this module keep
+ * working unchanged.
  */
-export function getPlanUsageBudgetCents(
-  plan: string | null | undefined,
-  _interval: BillingInterval = 'monthly',
-): number {
-  if (isPlanUsageUncapped(plan)) return MANAGED_USAGE_UNCAPPED_LEDGER_ALLOCATION_CENTS;
-  // Free is metered in the separate micro-USD reservation ledger because its
-  // five-hour and weekly allocations contain half-cent units.
-  if (getLimit(plan) === MANAGED_USAGE_LIMITS.free) return 0;
-  return unitsToLedgerCents(getPlanMonthlyUsageUnits(plan));
-}
+export {
+  MANAGED_USAGE_UNCAPPED_LEDGER_ALLOCATION_CENTS,
+  toPublicUsagePercentage,
+  getPlanMonthlyUsageUnits,
+  getPlanWeeklyUsageUnits,
+  getPlanDailyUsageUnits,
+  getPlanFiveHourUsageUnits,
+  getPlanMonthlyUsageBudgetMicrousd,
+  getPlanWeeklyUsageBudgetMicrousd,
+  getPlanFiveHourUsageBudgetMicrousd,
+  getInternalUsageUnitMicrousd,
+  isPlanUsageUncapped,
+  getPlanUsageBudgetCents,
+  getPlanWeeklyUsageBudgetCents,
+  getPlanSessionUsageBudgetCents,
+  getPlanFlagshipWeeklyUsageBudgetCents,
+  getPlanSessionUsageCapCents,
+  getPlanWeeklyUsageCapCents,
+  getPlanFlagshipWeeklyUsageCapCents,
+} from '@agiworkforce/types';
+export type { ManagedUsageCapCents } from '@agiworkforce/types';
 
-export function getPlanWeeklyUsageBudgetCents(plan: string | null | undefined): number {
-  if (getLimit(plan) === MANAGED_USAGE_LIMITS.free) return 0;
-  return unitsToLedgerCents(getPlanWeeklyUsageUnits(plan));
-}
-
-export function getPlanSessionUsageBudgetCents(plan: string | null | undefined): number {
-  if (getLimit(plan) === MANAGED_USAGE_LIMITS.free) return 0;
-  return unitsToLedgerCents(getPlanFiveHourUsageUnits(plan));
-}
-
-export function getPlanFlagshipWeeklyUsageBudgetCents(plan: string | null | undefined): number {
-  return Math.round(getPlanWeeklyUsageBudgetCents(plan) * FLAGSHIP_OF_WEEKLY_BUDGET_RATIO);
-}
-
-/**
- * GOV-1: the rolling ceilings actually handed to SQL.
- *
- * `null` is passed only for a tier that DECLARES itself uncapped; every other
- * tier — including one whose numeric allowance is 0 — gets a number, and the
- * migration's `is not null` guard turns 0 into a denial instead of a bypass.
- */
-export function getPlanSessionUsageCapCents(plan: string | null | undefined): ManagedUsageCapCents {
-  return isPlanUsageUncapped(plan) ? null : getPlanSessionUsageBudgetCents(plan);
-}
-
-export function getPlanWeeklyUsageCapCents(plan: string | null | undefined): ManagedUsageCapCents {
-  return isPlanUsageUncapped(plan) ? null : getPlanWeeklyUsageBudgetCents(plan);
-}
-
-export function getPlanFlagshipWeeklyUsageCapCents(
-  plan: string | null | undefined,
-): ManagedUsageCapCents {
-  return isPlanUsageUncapped(plan) ? null : getPlanFlagshipWeeklyUsageBudgetCents(plan);
-}
+import {
+  getPlanWeeklyUsageBudgetCents,
+  getPlanSessionUsageBudgetCents,
+  isPlanUsageUncapped,
+  toPublicUsagePercentage,
+} from '@agiworkforce/types';
 
 /* ────────────────────────────────────────────────────────────────────────────
  * GOV-18: the `X-Quota-Warning` producer.

--- a/docs/agent-context/generated/contract-registry.json
+++ b/docs/agent-context/generated/contract-registry.json
@@ -27,6 +27,7 @@
     "event-triggers",
     "interactive-cards",
     "managed-usage-balance",
+    "managed-usage-caps",
     "memory",
     "model",
     "model-catalog",

--- a/packages/contracts/types/src/index.ts
+++ b/packages/contracts/types/src/index.ts
@@ -207,3 +207,4 @@ export * from './sessions';
 // Server-authoritative effective-capability handshake (model ∩ tier ∩
 // surface ∩ settings) — W5 discipline wave 1, six-app report finding A.
 export * from './capability-handshake';
+export * from './managed-usage-caps';

--- a/packages/contracts/types/src/managed-usage-caps.ts
+++ b/packages/contracts/types/src/managed-usage-caps.ts
@@ -1,0 +1,245 @@
+/**
+ * Managed-compute usage ceilings — the ONE definition both surfaces read.
+ *
+ * This lived in `apps/web/lib/server/managed-usage-policy.ts` behind
+ * `import 'server-only'`, which made it unreachable from `services/api-gateway`.
+ * The gateway therefore called the legacy `reserve_managed_usage_request(...)`
+ * with no ceilings at all, while apps/web called
+ * `reserve_managed_usage_request_with_limits(...)` with all three — so desktop,
+ * CLI and the VS Code extension enforced no rolling five-hour, weekly or
+ * flagship limit whatsoever. The capped SQL function is a wrapper that
+ * delegates to the legacy one after checking, so the gateway was literally
+ * "the same reservation, minus every cap".
+ *
+ * It is a contract two surfaces must agree on, so it belongs here next to
+ * `billing-catalog.ts` rather than inside one app. `apps/web` re-exports every
+ * symbol, so nothing there changed.
+ *
+ * These values are PRIVATE. They must never be serialized into pricing, usage
+ * or client configuration responses; public clients get percentages and reset
+ * times only.
+ */
+import type { BillingInterval, BillingPlanTier } from './billing-catalog';
+
+interface ManagedUsageLimit {
+  monthlyUnits: number;
+  weeklyUnits: number;
+  fiveHourUnits: number;
+  dailyUnits: number;
+  /**
+   * GOV-1: explicit "this tier has NO configured spend ceiling" marker.
+   *
+   * Before this flag every tier expressed "no cap" and "cap of zero" with the
+   * same value (0), and the SQL guard `p_*_cap_cents > 0` turned that single
+   * value into UNLIMITED. That inverted fail-closed: Enterprise (an all-zero
+   * row) had no rolling ceiling at all on the only durable usage gate.
+   *
+   * The two states are now distinct and the DEFAULT IS DENY:
+   *   unlimited: true  -> cap resolves to null -> SQL treats it as no ceiling
+   *   unlimited: false -> cap resolves to a number; 0 means "deny every
+   *                       reservation against this ledger", not "unlimited"
+   */
+  unlimited: boolean;
+}
+
+/**
+ * A resolved rolling/period ceiling in paid-ledger cents.
+ * `null` = explicitly uncapped (negotiated contract). A number is a hard
+ * ceiling, and 0 denies every reservation.
+ */
+export type ManagedUsageCapCents = number | null;
+
+/**
+ * GOV-2: ledger allocation used for tiers whose contract carries no numeric
+ * monthly allowance (Enterprise). The paid ledger still needs a real account —
+ * `CreditService.checkAvailable` returns false without one, which hard-blocked
+ * every Enterprise chat with "Usage budget exhausted. Upgrade your plan".
+ *
+ * This is HEADROOM, NOT A PRICE OR A SPEND CEILING: an uncapped tier's actual
+ * governor is its negotiated contract plus the rolling caps above (which
+ * resolve to null for it). It exists only so the cents ledger has an account
+ * to debit against.
+ */
+export const MANAGED_USAGE_UNCAPPED_LEDGER_ALLOCATION_CENTS = 100_000_000;
+
+/**
+ * Private managed-compute allowances. These values must never be serialized
+ * into pricing, usage, or client configuration responses. Public clients get
+ * percentages and reset times only.
+ */
+const MANAGED_USAGE_LIMITS: Readonly<Record<BillingPlanTier, ManagedUsageLimit>> = Object.freeze({
+  // Local trust boundary: never admitted to managed compute. Zero WITHOUT the
+  // unlimited marker now means deny, which is what these tiers must get.
+  'local-only': {
+    monthlyUnits: 0,
+    weeklyUnits: 0,
+    fiveHourUnits: 0,
+    dailyUnits: 0,
+    unlimited: false,
+  },
+  byok: { monthlyUnits: 0, weeklyUnits: 0, fiveHourUnits: 0, dailyUnits: 0, unlimited: false },
+  // Free's allowance is real but lives in the separate micro-USD reservation
+  // ledger; against the PAID cents ledger its cap is 0 = deny.
+  free: { monthlyUnits: 20, weeklyUnits: 15, fiveHourUnits: 5, dailyUnits: 0, unlimited: false },
+  basic: {
+    monthlyUnits: 400,
+    weeklyUnits: 100,
+    fiveHourUnits: 20,
+    dailyUnits: 0,
+    unlimited: false,
+  },
+  pro: {
+    monthlyUnits: 2_000,
+    weeklyUnits: 500,
+    fiveHourUnits: 100,
+    dailyUnits: 0,
+    unlimited: false,
+  },
+  max: {
+    monthlyUnits: 10_000,
+    weeklyUnits: 2_500,
+    fiveHourUnits: 500,
+    dailyUnits: 0,
+    unlimited: false,
+  },
+  max_15x: {
+    monthlyUnits: 30_000,
+    weeklyUnits: 7_500,
+    fiveHourUnits: 1_500,
+    dailyUnits: 0,
+    unlimited: false,
+  },
+  team: {
+    monthlyUnits: 2_000,
+    weeklyUnits: 500,
+    fiveHourUnits: 100,
+    dailyUnits: 0,
+    unlimited: false,
+  },
+  // Negotiated contract: DELIBERATELY uncapped, declared rather than inferred
+  // from a zero. Its spend governor is the contract, not this table.
+  enterprise: {
+    monthlyUnits: 0,
+    weeklyUnits: 0,
+    fiveHourUnits: 0,
+    dailyUnits: 0,
+    unlimited: true,
+  },
+});
+
+const INTERNAL_USAGE_UNITS_PER_LEDGER_CENT = 2;
+const MICROUSD_PER_INTERNAL_USAGE_UNIT = 5_000;
+const FLAGSHIP_OF_WEEKLY_BUDGET_RATIO = 0.3;
+
+/** Convert private server ledger values to the only public numeric usage value. */
+export function toPublicUsagePercentage(used: number, limit: number): number {
+  if (limit <= 0) return 0;
+  const boundedUsed = Math.min(limit, Math.max(0, used));
+  return Math.round((boundedUsed / limit) * 10_000) / 100;
+}
+
+function getLimit(plan: string | null | undefined): ManagedUsageLimit | null {
+  if (!plan) return null;
+  const normalized = plan.trim().toLowerCase() as BillingPlanTier;
+  return Object.prototype.hasOwnProperty.call(MANAGED_USAGE_LIMITS, normalized)
+    ? MANAGED_USAGE_LIMITS[normalized]
+    : null;
+}
+
+export function getPlanMonthlyUsageUnits(plan: string | null | undefined): number {
+  return getLimit(plan)?.monthlyUnits ?? 0;
+}
+
+export function getPlanWeeklyUsageUnits(plan: string | null | undefined): number {
+  return getLimit(plan)?.weeklyUnits ?? 0;
+}
+
+export function getPlanDailyUsageUnits(plan: string | null | undefined): number {
+  return getLimit(plan)?.dailyUnits ?? 0;
+}
+
+export function getPlanFiveHourUsageUnits(plan: string | null | undefined): number {
+  return getLimit(plan)?.fiveHourUnits ?? 0;
+}
+
+export function getPlanMonthlyUsageBudgetMicrousd(plan: string | null | undefined): number {
+  return getPlanMonthlyUsageUnits(plan) * MICROUSD_PER_INTERNAL_USAGE_UNIT;
+}
+
+export function getPlanWeeklyUsageBudgetMicrousd(plan: string | null | undefined): number {
+  return getPlanWeeklyUsageUnits(plan) * MICROUSD_PER_INTERNAL_USAGE_UNIT;
+}
+
+export function getPlanFiveHourUsageBudgetMicrousd(plan: string | null | undefined): number {
+  return getPlanFiveHourUsageUnits(plan) * MICROUSD_PER_INTERNAL_USAGE_UNIT;
+}
+
+export function getInternalUsageUnitMicrousd(): number {
+  return MICROUSD_PER_INTERNAL_USAGE_UNIT;
+}
+
+function unitsToLedgerCents(units: number): number {
+  if (units <= 0) return 0;
+  if (units % INTERNAL_USAGE_UNITS_PER_LEDGER_CENT !== 0) {
+    throw new Error('Managed usage allocation cannot be represented by the paid cents ledger');
+  }
+  return units / INTERNAL_USAGE_UNITS_PER_LEDGER_CENT;
+}
+
+/** GOV-1: whether `plan` is declared as having no configured spend ceiling. */
+export function isPlanUsageUncapped(plan: string | null | undefined): boolean {
+  return getLimit(plan)?.unlimited === true;
+}
+
+/**
+ * Paid billing-period allocation for the existing cents ledger.
+ *
+ * GOV-2: an uncapped tier resolves to real ledger headroom instead of 0, so
+ * `allocateCreditsForPeriod` actually creates its credit account and
+ * `CreditService.checkAvailable` stops 402-ing the highest-paying tier.
+ */
+export function getPlanUsageBudgetCents(
+  plan: string | null | undefined,
+  _interval: BillingInterval = 'monthly',
+): number {
+  if (isPlanUsageUncapped(plan)) return MANAGED_USAGE_UNCAPPED_LEDGER_ALLOCATION_CENTS;
+  // Free is metered in the separate micro-USD reservation ledger because its
+  // five-hour and weekly allocations contain half-cent units.
+  if (getLimit(plan) === MANAGED_USAGE_LIMITS.free) return 0;
+  return unitsToLedgerCents(getPlanMonthlyUsageUnits(plan));
+}
+
+export function getPlanWeeklyUsageBudgetCents(plan: string | null | undefined): number {
+  if (getLimit(plan) === MANAGED_USAGE_LIMITS.free) return 0;
+  return unitsToLedgerCents(getPlanWeeklyUsageUnits(plan));
+}
+
+export function getPlanSessionUsageBudgetCents(plan: string | null | undefined): number {
+  if (getLimit(plan) === MANAGED_USAGE_LIMITS.free) return 0;
+  return unitsToLedgerCents(getPlanFiveHourUsageUnits(plan));
+}
+
+export function getPlanFlagshipWeeklyUsageBudgetCents(plan: string | null | undefined): number {
+  return Math.round(getPlanWeeklyUsageBudgetCents(plan) * FLAGSHIP_OF_WEEKLY_BUDGET_RATIO);
+}
+
+/**
+ * GOV-1: the rolling ceilings actually handed to SQL.
+ *
+ * `null` is passed only for a tier that DECLARES itself uncapped; every other
+ * tier — including one whose numeric allowance is 0 — gets a number, and the
+ * migration's `is not null` guard turns 0 into a denial instead of a bypass.
+ */
+export function getPlanSessionUsageCapCents(plan: string | null | undefined): ManagedUsageCapCents {
+  return isPlanUsageUncapped(plan) ? null : getPlanSessionUsageBudgetCents(plan);
+}
+
+export function getPlanWeeklyUsageCapCents(plan: string | null | undefined): ManagedUsageCapCents {
+  return isPlanUsageUncapped(plan) ? null : getPlanWeeklyUsageBudgetCents(plan);
+}
+
+export function getPlanFlagshipWeeklyUsageCapCents(
+  plan: string | null | undefined,
+): ManagedUsageCapCents {
+  return isPlanUsageUncapped(plan) ? null : getPlanFlagshipWeeklyUsageBudgetCents(plan);
+}

--- a/services/api-gateway/__tests__/routes/llm-provider-model-id.test.ts
+++ b/services/api-gateway/__tests__/routes/llm-provider-model-id.test.ts
@@ -13,6 +13,7 @@ type AdapterMode =
   | 'throw-before-token'
   | 'throw-after-token'
   | 'slow-before-token'
+  | 'deltas-then-client-abort'
   | 'slow-until-client-abort'
   | 'backpressure'
   | 'backpressure-timeout'
@@ -229,6 +230,23 @@ vi.mock('../../src/lib/providerAdapters', () => ({
         }
         if (state.adapterMode === 'slow-before-token') {
           await new Promise((resolve) => setTimeout(resolve, 50));
+          if (signal?.aborted) throw signal.reason;
+          return;
+        }
+        if (state.adapterMode === 'deltas-then-client-abort') {
+          yield { type: 'text-delta', delta: 'a long answer' };
+          yield {
+            type: 'usage',
+            inputTokens: 1_000,
+            outputTokens: 4_000,
+          } as unknown as StreamChunk;
+          await new Promise<void>((resolve) => {
+            if (signal?.aborted) {
+              resolve();
+              return;
+            }
+            signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
           if (signal?.aborted) throw signal.reason;
           return;
         }
@@ -524,6 +542,37 @@ describe('Gateway OpenAI-compatible provider model IDs', () => {
       error: 'The upstream provider timed out. Please retry.',
     });
     expect(state.billingEvents.filter((event) => event === 'finalize-failed')).toHaveLength(1);
+  });
+
+  it('bills a client disconnect that already received tokens instead of releasing it free', async () => {
+    // The existing disconnect test below passes because its adapter emits NO
+    // chunks — the legitimately-free zero-token case. Nothing covered "deltas
+    // delivered, then abort", which settled as `failed` and therefore at zero
+    // cost while the provider had already charged us. That made "read the
+    // answer, then close the socket" unlimited free inference, and unbounded:
+    // a zero settle records no deduction, so the rolling windows never saw it.
+    state.adapterMode = 'deltas-then-client-abort';
+
+    const outbound = request(createApp())
+      .post('/api/llm/v1/chat/completions')
+      .send({
+        model: 'claude-opus-5',
+        messages: [{ role: 'user', content: 'hello' }],
+        stream: true,
+      });
+    const settled = outbound.then(
+      () => 'response' as const,
+      () => 'aborted' as const,
+    );
+
+    await vi.waitFor(() => expect(state.capturedSignal).toBeInstanceOf(AbortSignal));
+    outbound.abort();
+    await settled;
+
+    await vi.waitFor(() =>
+      expect(state.billingEvents.filter((event) => event === 'finalize-completed')).toHaveLength(1),
+    );
+    expect(state.billingEvents.filter((event) => event === 'finalize-failed')).toHaveLength(0);
   });
 
   it('cancels and releases the upstream iterator when the client disconnects', async () => {

--- a/services/api-gateway/__tests__/services/managedUsageBilling.test.ts
+++ b/services/api-gateway/__tests__/services/managedUsageBilling.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  getPlanFlagshipWeeklyUsageCapCents,
+  getPlanSessionUsageCapCents,
+  getPlanWeeklyUsageCapCents,
+} from '@agiworkforce/types';
+
+import {
   calculateManagedUsageCostCents,
   estimateManagedUsageCostCents,
   fingerprintManagedUsageRequest,
@@ -377,6 +383,7 @@ describe('managed usage durable lifecycle client', () => {
       idempotencyKey: 'turn_12345678',
       provider: 'anthropic',
       request: requestBody,
+      planTier: 'pro',
       leaseToken: 'lease-1',
     });
 
@@ -386,16 +393,28 @@ describe('managed usage durable lifecycle client', () => {
       estimatedCostCents: 2,
       requestStatus: 'reserved',
     });
+    // `_with_limits`, and the ceilings must actually be present. This asserted
+    // the legacy 8-argument `reserve_managed_usage_request`, which performs no
+    // rolling-window accounting at all — so it passed for as long as the
+    // gateway enforced no five-hour, weekly or flagship cap on desktop, CLI and
+    // VS Code traffic. Pinning the capped function and a real ceiling is the
+    // only version of this assertion that can catch that regression.
     expect(rpc).toHaveBeenCalledWith(
-      'reserve_managed_usage_request',
+      'reserve_managed_usage_request_with_limits',
       expect.objectContaining({
         p_user_id: 'user-1',
         p_idempotency_key: 'turn_12345678',
         p_provider: 'anthropic',
         p_model: 'claude-opus-5',
         p_lease_token: 'lease-1',
+        p_session_cap_cents: getPlanSessionUsageCapCents('pro'),
+        p_weekly_cap_cents: getPlanWeeklyUsageCapCents('pro'),
+        p_flagship_weekly_cap_cents: getPlanFlagshipWeeklyUsageCapCents('pro'),
       }),
     );
+    const reserveArgs = rpc.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(reserveArgs['p_session_cap_cents']).toBeGreaterThan(0);
+    expect(reserveArgs['p_weekly_cap_cents']).toBeGreaterThan(0);
   });
 
   it.each([

--- a/services/api-gateway/src/routes/llm.ts
+++ b/services/api-gateway/src/routes/llm.ts
@@ -408,6 +408,10 @@ router.post(
         idempotencyKey,
         provider,
         request: body as ManagedUsageRequestBody,
+        // The rolling five-hour, weekly and flagship ceilings are per-tier.
+        // Without this the reservation cannot be capped at all — which is
+        // exactly what this path did before 2026-08-08.
+        planTier: tier,
       });
       await markManagedUsageProviderStarted({
         client: usageDb,
@@ -469,7 +473,23 @@ router.post(
     const releaseFailedReservation = async (reason: string): Promise<void> => {
       if (billingFinalized || providerSuccessObserved) return;
       try {
-        await finalizeBilling('failed');
+        /**
+         * A client that walks away after we already streamed it tokens is not a
+         * failure, and must not be billed as one.
+         *
+         * `finalizeManagedUsage` forces `actual_cost_cents` to 0 on `failed`,
+         * and migration 0056 refunds the whole reservation — so "read the
+         * answer, then close the socket" cost nothing while the provider had
+         * already charged us for every token. It was unbounded rather than
+         * merely cheap: a zero settle records no deduction, so it never counted
+         * toward the rolling five-hour, weekly or flagship windows either.
+         *
+         * Only an attempt that produced NOTHING is still released in full —
+         * that is the genuine-failure case the zeroing rule exists for.
+         */
+        const deliveredTokens =
+          (actualUsage.inputTokens ?? 0) + (actualUsage.outputTokens ?? 0) > 0;
+        await finalizeBilling(deliveredTokens ? 'completed' : 'failed');
       } catch (error) {
         logger.error(
           {

--- a/services/api-gateway/src/services/managedUsageBilling.ts
+++ b/services/api-gateway/src/services/managedUsageBilling.ts
@@ -2,6 +2,10 @@ import { createHash, randomUUID } from 'node:crypto';
 
 import {
   getModelMetadataById,
+  getPlanFlagshipWeeklyUsageCapCents,
+  getPlanSessionUsageCapCents,
+  getPlanWeeklyUsageCapCents,
+  getSlotForModel,
   normalizeModelId,
   resolveEffectiveModelPricing,
   type StreamChunkUsage,
@@ -306,13 +310,39 @@ export async function reserveManagedUsage(input: {
   idempotencyKey: string;
   provider: string;
   request: ManagedUsageRequestBody;
+  /**
+   * REQUIRED. The rolling ceilings are per-tier, so a reservation without a
+   * tier cannot be capped — see the note on the RPC call below.
+   */
+  planTier: string;
   leaseToken?: string;
 }): Promise<ManagedUsageReservation> {
   const idempotencyKey = parseManagedUsageIdempotencyKey(input.idempotencyKey);
   const requestHash = fingerprintManagedUsageRequest(input.request);
   const estimatedCostCents = estimateManagedUsageCostCents(input.request);
   const leaseToken = input.leaseToken ?? randomUUID();
-  const row = await callBillingRpc(input.client, 'reserve_managed_usage_request', {
+
+  /**
+   * `_with_limits`, NOT the bare `reserve_managed_usage_request`.
+   *
+   * This called the legacy 8-argument function with no ceilings at all, while
+   * apps/web called this one with all three. The capped function is a wrapper
+   * that delegates to the legacy one after checking, so the gateway was
+   * literally "the same reservation, minus every cap" — and the gateway is the
+   * endpoint desktop, CLI and the VS Code extension use. A single user could
+   * burn an entire monthly allocation inside one five-hour window, all of it on
+   * flagship models, and nothing on this path would decline it.
+   *
+   * `is_flagship` matters beyond this request: it is stamped onto the
+   * settlement metadata only inside `_with_limits`, and the flagship weekly
+   * window filters on that tag. Reserving through the legacy function left
+   * gateway spend invisible to the flagship ceiling even for later apps/web
+   * checks.
+   */
+  const slot = getSlotForModel(input.request.model);
+  const isFlagship = slot === 'flagship_coding_pro_plus' || slot === 'flagship_general_pro_plus';
+
+  const row = await callBillingRpc(input.client, 'reserve_managed_usage_request_with_limits', {
     p_user_id: input.userId,
     p_idempotency_key: idempotencyKey,
     p_request_hash: requestHash,
@@ -321,6 +351,10 @@ export async function reserveManagedUsage(input: {
     p_estimated_cost_cents: estimatedCostCents,
     p_lease_token: leaseToken,
     p_lease_seconds: 15 * 60,
+    p_session_cap_cents: getPlanSessionUsageCapCents(input.planTier),
+    p_weekly_cap_cents: getPlanWeeklyUsageCapCents(input.planTier),
+    p_flagship_weekly_cap_cents: getPlanFlagshipWeeklyUsageCapCents(input.planTier),
+    p_is_flagship: isFlagship,
   });
 
   const decision = row['reservation_decision'];


### PR DESCRIPTION
Two verified money holes on the endpoint **desktop, CLI and the VS Code extension** use.

## 1. The gateway enforced no rolling caps at all

It called the legacy 8-arg `reserve_managed_usage_request(...)` with no ceilings. `apps/web` calls `reserve_managed_usage_request_with_limits(...)` with all three. The capped function is a **wrapper that delegates to the legacy one after checking** — so the gateway was literally *the same reservation, minus every cap*. One user could burn a whole monthly allocation inside a single five-hour window, all on flagship models, and nothing declined it.

**The cause was structural.** The ceiling policy lived in `apps/web/lib/server/managed-usage-policy.ts` behind `import 'server-only'`, so the gateway *could not reach it*. Duplicating the table would have recreated the drift, so the policy moved to `@agiworkforce/types` beside `billing-catalog.ts` — one definition, both surfaces. `apps/web` re-exports every symbol, so nothing there changed.

`is_flagship` matters beyond its own request: it's stamped onto settlement metadata only inside `_with_limits`, and the flagship weekly window filters on that tag. Reserving through the legacy function left gateway spend invisible to the flagship ceiling **even for later apps/web checks**.

## 2. Abandoned streams cost nothing

A client that walked away after receiving tokens settled as `failed`, which forces `actual_cost_cents` to 0 and refunds the reservation. "Read the answer, then close the socket" was free while the provider had already charged us — and unbounded, since a zero settle records no deduction and never reaches the rolling windows. Only a request that produced **nothing** is still released in full.

## Tests

- The reservation test asserted the **legacy function name**, so it stayed green for exactly as long as the gateway enforced no caps. It now pins `_with_limits` and asserts non-zero ceilings.
- The existing disconnect test passes only because its adapter emits no chunks. Added a `deltas-then-client-abort` mode and a test — and **confirmed it FAILS against the old settlement line** before restoring the fix. A regression test that passes either way is worthless.

Gateway 276 pass · web 6,549 pass · both typecheck clean.