### PR TITLE
fix(billing): provision new organizations with the seats already paid for

### DIFF
--- a/apps/web/app/api/settings/organization/__tests__/route.creation.test.ts
+++ b/apps/web/app/api/settings/organization/__tests__/route.creation.test.ts
@@ -2,11 +2,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('server-only', () => ({}));
 
-const { mockQuery, mockExecute, mockTransaction, mockTeamAccess } = vi.hoisted(() => ({
-  mockQuery: vi.fn(),
-  mockExecute: vi.fn(),
-  mockTransaction: vi.fn(),
-  mockTeamAccess: vi.fn(),
+const { mockQuery, mockExecute, mockTransaction, mockTeamAccess, mockPurchasedSeats } = vi.hoisted(
+  () => ({
+    mockQuery: vi.fn(),
+    mockExecute: vi.fn(),
+    mockTransaction: vi.fn(),
+    mockTeamAccess: vi.fn(),
+    mockPurchasedSeats: vi.fn(),
+  }),
+);
+
+vi.mock('@/lib/server/purchased-seats', () => ({
+  resolvePurchasedSeatsForOwner: (...args: unknown[]) => mockPurchasedSeats(...args),
 }));
 
 vi.mock('@/lib/rate-limit', () => ({
@@ -61,6 +68,9 @@ function createRequest(body: unknown) {
 describe('organization creation and plan response', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no purchased-seat record recovered, which is the pre-existing
+    // shape every assertion below was written against.
+    mockPurchasedSeats.mockResolvedValue(null);
     mockTeamAccess.mockResolvedValue({
       plan: 'team',
       canManageTeam: true,
@@ -88,6 +98,9 @@ describe('organization creation and plan response', () => {
     expect(mockQuery.mock.calls[0]?.[0]).toContain('pg_advisory_xact_lock');
     expect(mockQuery.mock.calls[1]?.[0]).toContain('organization_members');
     expect(mockQuery.mock.calls[2]?.[0]).toContain('insert into public.organizations');
+    // Nothing was recovered, so the insert must NOT name licensed_seats and the
+    // row falls to migration 0085's default.
+    expect(mockQuery.mock.calls[2]?.[0]).not.toContain('licensed_seats');
     expect(mockExecute).toHaveBeenCalledWith(
       expect.stringContaining('insert into public.organization_members'),
       [organizationId, 'team-owner', 'owner'],
@@ -102,6 +115,49 @@ describe('organization creation and plan response', () => {
       maxMembers: null,
       currentUserRole: 'owner',
     });
+  });
+
+  it('provisions the organization with the seat count the owner already paid for', async () => {
+    // The buyer purchased Team seats before creating their organization, so the
+    // webhook's owner-matched seat write returned `no_organization` and dropped
+    // the count. Without adoption here the row lands on `licensed_seats default
+    // 1` and the second invitation trips organizations_seats_within_license —
+    // a 409 telling a paying customer to buy seats they already own.
+    mockPurchasedSeats.mockResolvedValue({
+      seats: 5,
+      planTier: 'team',
+      stripeSubscriptionId: 'sub_paid',
+      stripeCustomerId: 'cus_paid',
+    });
+    mockQuery
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([organization]);
+    mockExecute.mockResolvedValueOnce(1);
+
+    const response = await POST(createRequest({ name: 'Demo Team', slug: 'demo-team' }));
+
+    expect(response.status).toBe(201);
+    // Resolved before the transaction: a Stripe round trip must not be held
+    // inside the advisory lock that serializes org creation for this user.
+    expect(mockPurchasedSeats).toHaveBeenCalledBefore(mockTransaction);
+
+    const [insertSql, insertParams] = mockQuery.mock.calls[2] as [string, unknown[]];
+    expect(insertSql).toContain('insert into public.organizations');
+    expect(insertSql).toContain('licensed_seats');
+    expect(insertSql).toContain('seat_billing_updated_at');
+    expect(insertParams).toEqual([
+      'Demo Team',
+      'demo-team',
+      'team-owner',
+      5,
+      'team',
+      'sub_paid',
+      'cus_paid',
+    ]);
+    // seats_consumed is trigger-maintained (0085) and must never be written by
+    // route code, even on the insert that provisions the license.
+    expect(insertSql).not.toContain('seats_consumed');
   });
 
   it('refuses a second organization after the serialized membership check finds one', async () => {

--- a/apps/web/app/api/settings/organization/route.ts
+++ b/apps/web/app/api/settings/organization/route.ts
@@ -9,6 +9,7 @@ import { logger } from '@/lib/logger';
 import { getClerkAuthUser } from '@/lib/api-auth';
 import { requireCsrfToken } from '@/lib/csrf';
 import { getNeonDb } from '@/lib/server/neon-db';
+import { resolvePurchasedSeatsForOwner } from '@/lib/server/purchased-seats';
 import type { OrganizationRow, OrganizationMemberRow } from '@/lib/server/neon-types';
 import { handleCorsPreflightRequest } from '@/lib/cors';
 import {
@@ -157,6 +158,15 @@ async function handleCreate(request: NextRequest) {
   const db = getNeonDb();
   const access = await requireTeamAdminAccess(db, userId);
 
+  // Seats are bought before the organization exists, so the webhook's
+  // owner-matched seat write found no row and reported `no_organization`.
+  // Recover the paid-for count here, or every Team customer lands on migration
+  // 0085's `licensed_seats default 1` and is told to buy seats they already
+  // own. Resolved OUTSIDE the transaction: it makes a Stripe call, and holding
+  // an advisory lock across a network round trip serializes org creation behind
+  // Stripe's latency. Null on any failure — see resolvePurchasedSeatsForOwner.
+  const purchasedSeats = await resolvePurchasedSeatsForOwner(db, userId);
+
   try {
     const organization = await db.transaction(async (tx) => {
       // Serialize provisioning by user so concurrent create requests cannot
@@ -179,12 +189,29 @@ async function handleCreate(request: NextRequest) {
         throw createError.conflict('You already belong to an organization');
       }
 
-      const [created] = await tx.query<OrganizationRow>(
-        `insert into public.organizations (name, slug, created_by)
-         values ($1, $2, $3)
-         returning id, name, slug, created_by, created_at, updated_at`,
-        [parsed.data.name, parsed.data.slug, userId],
-      );
+      const [created] = purchasedSeats
+        ? await tx.query<OrganizationRow>(
+            `insert into public.organizations
+               (name, slug, created_by, licensed_seats, billing_plan_tier,
+                stripe_subscription_id, stripe_customer_id, seat_billing_updated_at)
+             values ($1, $2, $3, $4, $5, $6, $7, now())
+             returning id, name, slug, created_by, created_at, updated_at`,
+            [
+              parsed.data.name,
+              parsed.data.slug,
+              userId,
+              purchasedSeats.seats,
+              purchasedSeats.planTier,
+              purchasedSeats.stripeSubscriptionId,
+              purchasedSeats.stripeCustomerId,
+            ],
+          )
+        : await tx.query<OrganizationRow>(
+            `insert into public.organizations (name, slug, created_by)
+             values ($1, $2, $3)
+             returning id, name, slug, created_by, created_at, updated_at`,
+            [parsed.data.name, parsed.data.slug, userId],
+          );
 
       if (!created) {
         throw createError.conflict('The organization could not be created');

--- a/apps/web/lib/server/__tests__/purchased-seats.test.ts
+++ b/apps/web/lib/server/__tests__/purchased-seats.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+const { mockGetSubscription } = vi.hoisted(() => ({
+  mockGetSubscription: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@/lib/services/subscription-service', () => ({
+  SubscriptionService: {
+    getSubscription: (...args: unknown[]) => mockGetSubscription(...args),
+  },
+}));
+
+import { resolvePurchasedSeatsForOwner } from '../purchased-seats';
+
+const db = {} as never;
+
+function stripeReturning(subscription: unknown) {
+  return { subscriptions: { retrieve: vi.fn(async () => subscription) } };
+}
+
+describe('resolvePurchasedSeatsForOwner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reads the seat count from the Stripe subscription item quantity', async () => {
+    mockGetSubscription.mockResolvedValue({
+      plan_tier: 'team',
+      status: 'active',
+      stripe_subscription_id: 'sub_123',
+    });
+
+    const result = await resolvePurchasedSeatsForOwner(
+      db,
+      'owner-1',
+      stripeReturning({
+        items: { data: [{ quantity: 7 }] },
+        customer: 'cus_123',
+      }) as never,
+    );
+
+    expect(result).toEqual({
+      seats: 7,
+      planTier: 'team',
+      stripeSubscriptionId: 'sub_123',
+      stripeCustomerId: 'cus_123',
+    });
+  });
+
+  it('accepts an expanded customer object as well as a customer id string', async () => {
+    mockGetSubscription.mockResolvedValue({
+      plan_tier: 'team',
+      status: 'active',
+      stripe_subscription_id: 'sub_123',
+    });
+
+    const result = await resolvePurchasedSeatsForOwner(
+      db,
+      'owner-1',
+      stripeReturning({
+        items: { data: [{ quantity: 3 }] },
+        customer: { id: 'cus_expanded' },
+      }) as never,
+    );
+
+    expect(result?.stripeCustomerId).toBe('cus_expanded');
+  });
+
+  it('returns null on a per-account plan so pro buyers never provision seats', async () => {
+    mockGetSubscription.mockResolvedValue({
+      plan_tier: 'pro',
+      status: 'active',
+      stripe_subscription_id: 'sub_123',
+    });
+
+    const stripe = stripeReturning({ items: { data: [{ quantity: 9 }] } });
+    await expect(resolvePurchasedSeatsForOwner(db, 'owner-1', stripe as never)).resolves.toBeNull();
+    expect(stripe.subscriptions.retrieve).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the Team plan is store-billed and has no Stripe subscription', async () => {
+    mockGetSubscription.mockResolvedValue({
+      plan_tier: 'team',
+      status: 'active',
+      stripe_subscription_id: null,
+      apple_original_transaction_id: '1000000123',
+    });
+
+    await expect(
+      resolvePurchasedSeatsForOwner(db, 'owner-1', stripeReturning({}) as never),
+    ).resolves.toBeNull();
+  });
+
+  it('falls back to null rather than throwing when Stripe is unreachable', async () => {
+    // Under-provisioning is recoverable — the next customer.subscription.updated
+    // webhook finds the organization and writes the real number. Failing the
+    // create call instead would leave a paying customer with no organization.
+    mockGetSubscription.mockResolvedValue({
+      plan_tier: 'team',
+      status: 'active',
+      stripe_subscription_id: 'sub_123',
+    });
+
+    const stripe = {
+      subscriptions: {
+        retrieve: vi.fn(async () => {
+          throw new Error('stripe is down');
+        }),
+      },
+    };
+
+    await expect(resolvePurchasedSeatsForOwner(db, 'owner-1', stripe as never)).resolves.toBeNull();
+  });
+
+  it('returns null when no Stripe client is configured', async () => {
+    mockGetSubscription.mockResolvedValue({
+      plan_tier: 'team',
+      status: 'active',
+      stripe_subscription_id: 'sub_123',
+    });
+
+    await expect(resolvePurchasedSeatsForOwner(db, 'owner-1', null)).resolves.toBeNull();
+  });
+
+  it('returns null when the user has no subscription at all', async () => {
+    mockGetSubscription.mockResolvedValue(null);
+
+    await expect(
+      resolvePurchasedSeatsForOwner(db, 'owner-1', stripeReturning({}) as never),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/web/lib/server/purchased-seats.ts
+++ b/apps/web/lib/server/purchased-seats.ts
@@ -1,0 +1,101 @@
+import 'server-only';
+
+import Stripe from 'stripe';
+import type { DatabaseAdapter } from '@agiworkforce/data-layer';
+import { isPerSeatBillingPlan } from '@agiworkforce/types';
+import { resolveSubscriptionSeats } from '@/app/api/stripe-webhook/lib/seats';
+import { SubscriptionService } from '@/lib/services/subscription-service';
+import { STRIPE_API_VERSION } from '@/lib/stripe-config';
+import { logger } from '@/lib/logger';
+
+/**
+ * Seats a buyer has already paid for, recovered at organization-creation time.
+ *
+ * WHY THIS EXISTS. `persistPurchasedSeatsOnOrganization` writes the purchased
+ * seat count onto the buyer's organization, matched by `owner_user_id`. A Team
+ * subscription can be — and normally is — bought BEFORE the buyer creates their
+ * organization, in which case that write finds no row and returns
+ * `no_organization`: the seats are paid for, the entitlement provisions, and
+ * the seat count is dropped on the floor. The organization is then inserted
+ * with `organizations.licensed_seats` at migration 0085's `default 1`, so a
+ * customer who paid for N seats can invite nobody — the second invitation
+ * fails the `organizations_seats_within_license` CHECK and the API answers 409
+ * "purchase more seats" to someone who already did.
+ *
+ * The two-seat purchase floor (`MIN_PURCHASABLE_SEATS`) makes that certain
+ * rather than merely likely: every Team purchase is now for at least 2 seats,
+ * so every organization created after a purchase is under-provisioned.
+ *
+ * AUTHORITY. The seat count is read live from the Stripe subscription ITEM
+ * quantity through `resolveSubscriptionSeats` — the same single derivation site
+ * the webhook uses — never from checkout metadata and never from a local
+ * snapshot. Organization creation happens once per customer, so the extra
+ * Stripe round trip is not on any hot path, and reading live means a seat count
+ * changed through the billing portal between purchase and org creation is still
+ * correct.
+ *
+ * FAILURE MODE. Every failure resolves to `null`, which leaves the insert on
+ * the migration default exactly as it behaves today. This can under-provision
+ * (recoverable: the next `customer.subscription.updated` webhook finds the org
+ * and writes the real number) but it can never over-provision, which would hand
+ * out seats nobody paid for.
+ */
+export interface PurchasedSeatProvisioning {
+  seats: number;
+  planTier: string;
+  stripeSubscriptionId: string;
+  stripeCustomerId: string | null;
+}
+
+function getStripeClient(): Stripe | null {
+  const secretKey = process.env['STRIPE_SECRET_KEY'];
+  if (!secretKey) return null;
+  return new Stripe(secretKey, { apiVersion: STRIPE_API_VERSION });
+}
+
+export async function resolvePurchasedSeatsForOwner(
+  db: DatabaseAdapter,
+  userId: string,
+  stripeClient: Pick<Stripe, 'subscriptions'> | null = getStripeClient(),
+): Promise<PurchasedSeatProvisioning | null> {
+  const subscription = await SubscriptionService.getSubscription(db, userId);
+  if (!subscription) return null;
+  if (!isPerSeatBillingPlan(subscription.plan_tier)) return null;
+
+  const stripeSubscriptionId = subscription.stripe_subscription_id;
+  if (!stripeSubscriptionId) {
+    // Store-billed (Apple/Google) or manually provisioned Team plans have no
+    // Stripe subscription to read a quantity from. Seats stay at the default.
+    logger.warn(
+      { userId, planTier: subscription.plan_tier },
+      'Per-seat subscription has no Stripe subscription id; organization seats left at the default',
+    );
+    return null;
+  }
+
+  if (!stripeClient) {
+    logger.error(
+      { userId, stripeSubscriptionId },
+      'STRIPE_SECRET_KEY is not configured; cannot adopt purchased seats onto the new organization',
+    );
+    return null;
+  }
+
+  try {
+    const stripeSubscription = await stripeClient.subscriptions.retrieve(stripeSubscriptionId);
+    const seats = resolveSubscriptionSeats(stripeSubscription);
+    const customer = stripeSubscription.customer;
+    return {
+      seats,
+      planTier: subscription.plan_tier,
+      stripeSubscriptionId,
+      stripeCustomerId: typeof customer === 'string' ? customer : (customer?.id ?? null),
+    };
+  } catch (error) {
+    logger.error(
+      { userId, stripeSubscriptionId, error },
+      'Failed to read purchased seats from Stripe; organization seats left at the default',
+    );
+    return null;
+  }
+}


### PR DESCRIPTION
ExecutionPlan **E-09**.

## The bug

A Team subscription is bought *before* the buyer creates an organization. `persistPurchasedSeatsOnOrganization` matches on `owner_user_id`, finds no row, and returns `no_organization` — the seats are paid for, the entitlement provisions, and the purchased count is dropped on the floor.

The organization is then inserted with `organizations.licensed_seats` at migration 0085's `default 1`. The second invitation trips the `organizations_seats_within_license` CHECK, and the API answers **409 telling a paying customer to purchase seats they already own**.

The two-seat purchase floor added in `7611c622b` turns that from likely into certain: every Team purchase is now for at least 2 seats, so every organization created after one is under-provisioned.

## The fix

`resolvePurchasedSeatsForOwner` reads the live Stripe subscription item quantity through the existing single derivation site (`resolveSubscriptionSeats`), and the insert carries `licensed_seats` plus the org-side Stripe anchors — so `seatSource` reports `billing` rather than `unprovisioned`.

Three deliberate choices:

- **Resolved outside the transaction.** It makes a Stripe call; holding the per-user advisory lock across a network round trip would serialize organization creation behind Stripe's latency.
- **Every failure resolves to `null`**, leaving the insert on the migration default exactly as it behaves today. That can under-provision — recoverable, since the next `customer.subscription.updated` finds the org and writes the real number — but it can never over-provision.
- **The insert never names `seats_consumed`**, which stays trigger-maintained.

## Verified, not assumed

- The `guard_organization_seats` trigger is `before update` only, so an INSERT naming `licensed_seats` is not rejected.
- `getNeonDb()` binds no subject, so it does not `SET LOCAL ROLE app_rls` — the grant restriction and the guard's `current_user = 'app_rls'` branch both do not apply.
- The new creation test **fails against the unfixed route** (the adoption call is never made) and passes with it.
- Web suite **6,557 passing** (8 new), typecheck clean.