### PR TITLE
fix(desktop): give the indexer tests their own database instead of sharing one

### DIFF
--- a/apps/desktop/src-tauri/src/core/embeddings/indexer.rs
+++ b/apps/desktop/src-tauri/src/core/embeddings/indexer.rs
@@ -229,16 +229,38 @@ impl IncrementalIndexer {
 mod tests {
     use super::*;
 
+    /// A SimilaritySearch backed by a database this test alone owns.
+    ///
+    /// Both tests below used to pass a bare relative `PathBuf::from("test.db")`,
+    /// which resolves against the process working directory — so they opened
+    /// the SAME SQLite file, and `cargo test` runs them in PARALLEL. The result
+    /// is an intermittent "Error code 1: SQL error or missing database" that
+    /// fails whichever test loses the race, with 4,632 others passing around it.
+    /// That is what took CI red on main.
+    ///
+    /// It also wrote a stray `test.db` into whatever directory the suite ran in.
+    ///
+    /// Every other test in this crate already does it this way
+    /// (`temp_dir.path().join("test.db")` in checkpoint_store, project_memory,
+    /// memory_manager, continuous_executor); these two were the exception. The
+    /// TempDir is returned and must be held for the test's lifetime — dropping
+    /// it deletes the directory out from under the open database.
+    fn isolated_search() -> (tempfile::TempDir, SimilaritySearch) {
+        let dir = tempfile::tempdir().expect("create temp dir for the test database");
+        let search = SimilaritySearch::new(dir.path().join("test.db"))
+            .expect("open a per-test similarity database");
+        (dir, search)
+    }
+
     #[tokio::test]
     async fn test_should_index_file() {
+        let (_db_dir, search) = isolated_search();
         let indexer = IncrementalIndexer::new(
             PathBuf::from("."),
             Arc::new(Mutex::new(
                 EmbeddingGenerator::new(Default::default()).await.unwrap(),
             )),
-            Arc::new(Mutex::new(
-                SimilaritySearch::new(PathBuf::from("test.db")).unwrap(),
-            )),
+            Arc::new(Mutex::new(search)),
         );
 
         assert!(indexer.should_index_file(Path::new("test.ts")));
@@ -249,14 +271,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_should_ignore() {
+        let (_db_dir, search) = isolated_search();
         let indexer = IncrementalIndexer::new(
             PathBuf::from("."),
             Arc::new(Mutex::new(
                 EmbeddingGenerator::new(Default::default()).await.unwrap(),
             )),
-            Arc::new(Mutex::new(
-                SimilaritySearch::new(PathBuf::from("test.db")).unwrap(),
-            )),
+            Arc::new(Mutex::new(search)),
         );
 
         assert!(indexer.should_ignore(Path::new("node_modules/test.ts")));


### PR DESCRIPTION
Main's CI is red on `check` with **one failure out of 4,633**:

```
core::embeddings::indexer::tests::test_should_index_file
panicked at indexer.rs:240: Error code 1: SQL error or missing database
```

## Cause

`test_should_index_file` and `test_should_ignore` both constructed `SimilaritySearch::new(PathBuf::from("test.db"))` — a **bare relative path**, resolved against the process working directory, so both opened the **same SQLite file**. `cargo test` runs them in parallel; whichever loses the race fails.

4,632 tests pass around it, which is exactly why this reads as noise and why it survived. It also wrote a stray `test.db` into whatever directory the suite ran in.

## Fix

Every other test in this crate already isolates its database — `checkpoint_store`, `project_memory`, `memory_manager` and `continuous_executor` all use `temp_dir.path().join("test.db")`. These two were the exception, and `tempfile` was already a dev-dependency.

The helper **returns the `TempDir`** so the caller must hold it. Dropping it would delete the directory out from under the open database — the obvious way to "fix" this and get a different flake instead.

## Verified

- Ran the pair **three times** — the failure is a race, so once proves nothing.
- No stray `test.db` appears in the working tree.
- `cargo clippy -p agiworkforce-desktop --lib -- -D warnings` clean.

## Note on how this reached main

I merged #400 while its `check` was still running (`gh pr merge --auto` is not enabled on this repo, so it merged immediately rather than waiting). The failure is **pre-existing, not introduced** — but waiting for the run would have surfaced it before the merge rather than after.