### PR TITLE
fix(web): trace argon2 into the serverless bundle to restore the api

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -102,3 +102,20 @@ lerna-debug.log
 
 # Vercel specific
 .vercel
+
+# Native and platform build outputs (2026-08-08)
+#
+# A CLI production deploy uploads the working directory. Without these the CLI
+# tries to push ~1.2GB and dies on "File size limit exceeded (100 MB)" — which
+# is why it was not a usable incident-response path during the argon2 outage.
+# None of it is an input to the web build.
+target
+apps/desktop/release
+apps/desktop/src-tauri/target
+apps/extension-vscode/.vscode-test
+apps/extension-vscode/*.vsix
+apps/mobile/ios/Pods
+apps/mobile/android/.gradle
+apps/mobile/android/app/build
+tmp
+.turbo/cache

--- a/apps/web/lib/api-auth.ts
+++ b/apps/web/lib/api-auth.ts
@@ -4,7 +4,13 @@ import type { NextRequest } from 'next/server';
 import { createError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
 import { auth } from '@clerk/nextjs/server';
-import { ApiKeyService } from '@/lib/services/api-key-service';
+// NOT a static import. `ApiKeyService` pulls in `argon2`, a native module, at
+// module scope — and 98 route files import this one. On 2026-08-07 that binary
+// failed to resolve in the serverless bundle and every one of those routes
+// returned an empty 500 for ~21 hours, including routes that never hash
+// anything. Importing it lazily, only on the API-key path, means a hashing
+// dependency can fail without taking the authenticated surface with it.
+// See the incident note in apps/web/next.config.ts.
 import { getNeonDb } from '@/lib/server/neon-db';
 import {
   isDeveloperTokenRevoked,
@@ -171,6 +177,7 @@ async function verifyApiKey(
   token: string,
 ): Promise<(AuthResult & { scopes: readonly string[] }) | null> {
   try {
+    const { ApiKeyService } = await import('@/lib/services/api-key-service');
     const apiKey = await ApiKeyService.verifyKey(token);
     if (!apiKey) return null;
     return { userId: apiKey.user_id, scopes: apiKey.scopes };

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -38,6 +38,33 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: false,
   },
+  /**
+   * INCIDENT 2026-08-07 → 2026-08-08: every authenticated API route returned an
+   * empty HTTP 500 for ~21 hours.
+   *
+   *   Failed to load external module argon2-…: No native build was found for
+   *   platform=linux arch=arm64 abi=137 node=24.18.0
+   *
+   * `argon2` ships real prebuilt binaries (`prebuildify --napi`, including
+   * `prebuilds/linux-arm64/`), and N-API is ABI-stable, so the reported `abi=137`
+   * was a symptom rather than the cause. The cause is that `node-gyp-build`
+   * locates those `.node` files by BUILDING A PATH AT RUNTIME. Next's static file
+   * tracing cannot see a path that does not exist as a literal import, so the
+   * binaries were never copied into the serverless bundle.
+   *
+   * `serverExternalPackages` stops the bundler inlining the package;
+   * `outputFileTracingIncludes` copies the prebuilds it cannot infer. Both are
+   * required — either alone still ships a package that cannot resolve its binary.
+   *
+   * Blast radius was 98 route files, because `lib/api-auth.ts` imports
+   * `ApiKeyService`, which imports `argon2` at module scope. That import is being
+   * made lazy in the same change so a hashing dependency can never again take
+   * down routes that do no hashing.
+   */
+  serverExternalPackages: ['argon2'],
+  outputFileTracingIncludes: {
+    '/api/**/*': ['../../node_modules/.pnpm/argon2@*/node_modules/argon2/prebuilds/**'],
+  },
   // Instrumentation is automatically enabled in Next.js 16+
   // See: apps/web/instrumentation.ts
   experimental: {


### PR DESCRIPTION
Restores the authenticated API. Confirmed live right now: `/api/health` → **200**, `/api/me` → **500**.

`argon2` resolves its `.node` binary at **runtime** via `node-gyp-build`, so Next's file tracer copied nothing and the serverless bundle shipped without a binary. 98 routes import `lib/api-auth` → `ApiKeyService` → `argon2` at module scope.

- `serverExternalPackages` stops the bundler inlining the package
- `outputFileTracingIncludes` copies the prebuilds the tracer cannot infer
- Both are required; either alone still ships a package that cannot resolve its binary
- The `ApiKeyService` import is made lazy so a hashing dependency can't again take down 98 routes that mostly don't hash

## Why this is web-only, deliberately

The same fix sits in #401 **alongside `ci.yml` and `deploy-production.yml` changes**. Those two files are `deployContract` in `scripts/production-deploy-scope.mjs`, so touching either sets **every** scope — `desktop-e2e` then runs and fails on a visual baseline at 3.13% against a 3.0% threshold that nothing has fixed.

This change resolves to:

```
web=true  gateway=false  signaling=false  desktop=false
native=false  extension=false  vscode=false  mobile=false
```

so the desktop, native and smoke jobs are **skipped** rather than failing.

That matters because the production gate is `workflows: ['CI'] → conclusion == 'success'`, and `desktop-e2e`, `web-a11y`, `clippy-all-features`, `macos-smoke`, `windows-smoke` are all jobs **inside** that workflow with no `continue-on-error`. Fixing `check` alone was never sufficient — I'd been describing it as the gate and it isn't.

#401 keeps the workflow improvements (Stripe boot env for the a11y lane, brew tap trust, and a deploy probe that hits an authenticated route because `/api/health` returns 200 through a total outage). Those land once the visual baseline is regenerated on Linux.