### PR TITLE
fix(web): run Clerk proxy on auth-aware root

### DIFF
--- a/apps/web/__tests__/proxy-public-route.test.ts
+++ b/apps/web/__tests__/proxy-public-route.test.ts
@@ -66,11 +66,21 @@ describe('web proxy', () => {
     expect(matchesProxy('/chat')).toBe(true);
   });
 
-  it('keeps public marketing pages out of Clerk session middleware while preserving CSP', async () => {
+  it('runs the auth-aware root page through Clerk session middleware while preserving CSP', async () => {
     clerkState.clerkPaths = [];
     const { proxy } = await import('../proxy');
 
     const response = await proxy(new NextRequest('http://localhost/'), {} as never);
+
+    expect(clerkState.clerkPaths).toEqual(['/']);
+    expect(response?.headers.get('Content-Security-Policy')).toContain("default-src 'self'");
+  });
+
+  it('keeps ordinary public marketing pages outside Clerk session middleware', async () => {
+    clerkState.clerkPaths = [];
+    const { proxy } = await import('../proxy');
+
+    const response = await proxy(new NextRequest('http://localhost/about'), {} as never);
 
     expect(clerkState.clerkPaths).toEqual([]);
     expect(response?.headers.get('Content-Security-Policy')).toContain("default-src 'self'");

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -231,7 +231,14 @@ export const proxy: NextMiddleware = async (request, event) => {
     return attachApiCors(request, buildCspResponse(request));
   }
 
-  if (isClerkSessionRoute(request)) {
+  // The root page is auth-aware: app/page.tsx calls auth() so signed-in users
+  // land in the product while signed-out users see marketing. It therefore
+  // needs Clerk's request context even though it is publicly reachable. Use a
+  // native exact-path check here instead of teaching Clerk's deprecated route
+  // matcher about a non-auth path. When `/` bypasses clerkMiddleware(), the
+  // signed-in RSC render throws "auth() was called but Clerk can't detect usage
+  // of clerkMiddleware()".
+  if (request.nextUrl.pathname === '/' || isClerkSessionRoute(request)) {
     const response = await clerkAwareProxy(request, event);
     return response ? attachApiCors(request, response) : response;
   }


### PR DESCRIPTION
## Production incident\n\nSigned-in requests to the auth-aware root page crash with Clerk digest 3549729625 because app/page.tsx calls auth() while proxy.ts bypasses clerkMiddleware() for /.\n\n## Fix\n\n- run only the exact root pathname through the existing Clerk-aware CSP proxy\n- preserve ordinary public marketing routing\n- add a discriminating root/about proxy regression\n\n## Verification\n\n- proxy suites: 24/24\n- Web typecheck\n- focused ESLint and Prettier\n- git diff --check\n- clean Next.js 16 production build\n- independent adversarial verifier: SOUND

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication-aware rendering for the home page.
  * Preserved existing security headers, redirects, API handling, and route behavior.
  * Updated public-page coverage to ensure the About page remains accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->